### PR TITLE
Add sessions list endpoint and Sessions tab

### DIFF
--- a/distri-types/src/stores.rs
+++ b/distri-types/src/stores.rs
@@ -3,6 +3,7 @@ use crate::{
     workflow::WorkflowStore,
 };
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::Value;
 use std::{collections::HashMap, sync::Arc};
@@ -80,6 +81,14 @@ impl std::fmt::Debug for InitializedStores {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub keys: Vec<String>,
+    pub key_count: usize,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
 // SessionStore trait - manages current conversation thread/run
 #[async_trait::async_trait]
 pub trait SessionStore: Send + Sync + std::fmt::Debug {
@@ -100,6 +109,11 @@ pub trait SessionStore: Send + Sync + std::fmt::Debug {
     async fn delete_value(&self, namespace: &str, key: &str) -> anyhow::Result<()>;
 
     async fn get_all_values(&self, namespace: &str) -> anyhow::Result<HashMap<String, Value>>;
+
+    async fn list_sessions(
+        &self,
+        namespace: Option<&str>,
+    ) -> anyhow::Result<Vec<SessionSummary>>;
 }
 #[async_trait::async_trait]
 pub trait SessionStoreExt: SessionStore {

--- a/distri-ui/src/App.tsx
+++ b/distri-ui/src/App.tsx
@@ -24,6 +24,7 @@ import ThreadsPage from './routes/home/ThreadsPage';
 import SettingsPage from './routes/home/SettingsPage';
 import NewAgentPage from './routes/home/NewAgentPage';
 import AgentDetailsPage from './routes/home/AgentDetailsPage';
+import SessionsPage from './routes/home/SessionsPage';
 import { Toaster } from './components/ui/sonner';
 
 function App() {
@@ -62,6 +63,7 @@ function App() {
                   <Route path="new" element={<NewAgentPage />} />
                   <Route path="agents/:agentId" element={<AgentDetailsPage />} />
                   <Route path="threads" element={<ThreadsPage />} />
+                  <Route path="sessions" element={<SessionsPage />} />
                   <Route path="settings" element={<SettingsPage />} />
                   <Route path="menu/account" element={<AccountPage />} />
                   <Route path="menu/account/pricing" element={<PricingPage />} />

--- a/distri-ui/src/hooks/useHomeFetch.ts
+++ b/distri-ui/src/hooks/useHomeFetch.ts
@@ -1,0 +1,21 @@
+import { useCallback } from 'react'
+import { BACKEND_URL } from '@/constants'
+import { useInitialization } from '@/components/TokenProvider'
+
+export function useHomeFetch() {
+  const { token } = useInitialization()
+
+  return useCallback(
+    (path: string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers || undefined)
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`)
+      }
+      return fetch(`${BACKEND_URL}${path}`, {
+        ...init,
+        headers,
+      })
+    },
+    [token],
+  )
+}

--- a/distri-ui/src/hooks/useHomeStats.ts
+++ b/distri-ui/src/hooks/useHomeStats.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { BACKEND_URL } from '@/constants'
+import { useHomeFetch } from '@/hooks/useHomeFetch'
 
 export interface HomeStats {
   total_agents?: number
@@ -12,13 +12,14 @@ export function useHomeStats() {
   const [stats, setStats] = useState<HomeStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const homeFetch = useHomeFetch()
 
   useEffect(() => {
     let cancelled = false
     const load = async () => {
       setLoading(true)
       try {
-        const res = await fetch(`${BACKEND_URL}/api/v1/home/stats`)
+        const res = await homeFetch('/api/v1/home/stats')
         if (res.ok) {
           const json = (await res.json()) as HomeStats
           if (!cancelled) {
@@ -41,9 +42,8 @@ export function useHomeStats() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [homeFetch])
 
   return { stats, loading, error }
 }
-
 

--- a/distri-ui/src/layouts/HomeLayout.tsx
+++ b/distri-ui/src/layouts/HomeLayout.tsx
@@ -19,7 +19,7 @@ import {
   SidebarProvider,
   SidebarSeparator,
 } from '@/components/ui/sidebar'
-import { ChevronUp, LogOut, Settings, Users, Home, MessageSquare, User2 } from 'lucide-react'
+import { ChevronUp, LogOut, Settings, Users, Home, MessageSquare, User2, History } from 'lucide-react'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { useAccount } from '@/components/AccountProvider'
@@ -28,6 +28,7 @@ const navItems = [
   { id: 'home', label: 'Home', href: '/home', icon: Home },
   { id: 'agents', label: 'Agents', href: '/home/agents', icon: Users },
   { id: 'threads', label: 'Threads', href: '/home/threads', icon: MessageSquare },
+  { id: 'sessions', label: 'Sessions', href: '/home/sessions', icon: History },
   { id: 'settings', label: 'Settings', href: '/home/settings', icon: Settings },
 ]
 

--- a/distri-ui/src/routes/home/SessionsPage.tsx
+++ b/distri-ui/src/routes/home/SessionsPage.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useHomeFetch } from '@/hooks/useHomeFetch'
+
+interface SessionListItem {
+  session_id: string
+  thread_id: string
+  key_count: number
+  keys: string[]
+  updated_at?: string | null
+  task_ids: string[]
+}
+
+const SessionsPage = () => {
+  const homeFetch = useHomeFetch()
+  const [sessions, setSessions] = useState<SessionListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [threadFilter, setThreadFilter] = useState('')
+  const [taskFilter, setTaskFilter] = useState('')
+  const [keyFilter, setKeyFilter] = useState('')
+
+  const loadSessions = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await homeFetch('/api/v1/session')
+      if (!res.ok) {
+        throw new Error(`Status ${res.status}`)
+      }
+      const payload = (await res.json()) as SessionListItem[]
+      setSessions(payload)
+    } catch (err: any) {
+      setError(err?.message || 'Failed to load sessions')
+      setSessions([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadSessions()
+  }, [homeFetch])
+
+  const filtered = useMemo(() => {
+    return sessions.filter((session) => {
+      const matchesThread = threadFilter
+        ? session.thread_id.toLowerCase().includes(threadFilter.toLowerCase())
+        : true
+      const matchesTask = taskFilter
+        ? session.task_ids.some((task) => task.toLowerCase().includes(taskFilter.toLowerCase()))
+        : true
+      const matchesKeys = keyFilter
+        ? session.keys.some((key) => key.toLowerCase().includes(keyFilter.toLowerCase()))
+        : true
+      return matchesThread && matchesTask && matchesKeys
+    })
+  }, [sessions, threadFilter, taskFilter, keyFilter])
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="mx-auto w-full max-w-none px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+        <Card className="border-border/70 bg-card/95">
+          <CardHeader className="flex flex-col gap-3 pb-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle className="text-base">Sessions</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Browse session storage and related task runs.
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={loadSessions}>
+              Refresh
+            </Button>
+          </CardHeader>
+          <CardContent className="space-y-4 pt-0">
+            <div className="grid gap-2 sm:grid-cols-3">
+              <Input
+                placeholder="Filter by thread ID…"
+                value={threadFilter}
+                onChange={(e) => setThreadFilter(e.target.value)}
+              />
+              <Input
+                placeholder="Filter by task ID…"
+                value={taskFilter}
+                onChange={(e) => setTaskFilter(e.target.value)}
+              />
+              <Input
+                placeholder="Filter by key…"
+                value={keyFilter}
+                onChange={(e) => setKeyFilter(e.target.value)}
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Session</th>
+                    <th className="px-3 py-2 font-medium">Thread</th>
+                    <th className="px-3 py-2 font-medium">Tasks</th>
+                    <th className="px-3 py-2 font-medium">Keys</th>
+                    <th className="px-3 py-2 font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading ? (
+                    <tr>
+                      <td className="px-3 py-3 text-muted-foreground" colSpan={5}>
+                        Loading…
+                      </td>
+                    </tr>
+                  ) : filtered.length === 0 ? (
+                    <tr>
+                      <td className="px-3 py-3 text-muted-foreground" colSpan={5}>
+                        No sessions found.
+                      </td>
+                    </tr>
+                  ) : (
+                    filtered.map((session) => {
+                      const visibleKeys = session.keys.slice(0, 3)
+                      const remaining = session.key_count - visibleKeys.length
+                      return (
+                        <tr key={session.session_id} className="border-t">
+                          <td className="px-3 py-2 max-w-[20rem]">
+                            <div className="truncate font-medium">{session.session_id}</div>
+                          </td>
+                          <td className="px-3 py-2 max-w-[20rem]">
+                            <div className="truncate">{session.thread_id}</div>
+                          </td>
+                          <td className="px-3 py-2">
+                            <div className="flex flex-wrap gap-1">
+                              {session.task_ids.length === 0 ? (
+                                <span className="text-muted-foreground">—</span>
+                              ) : (
+                                session.task_ids.slice(0, 2).map((taskId) => (
+                                  <Badge key={taskId} variant="secondary" className="font-mono text-xs">
+                                    {taskId}
+                                  </Badge>
+                                ))
+                              )}
+                              {session.task_ids.length > 2 && (
+                                <Badge variant="outline" className="text-xs">
+                                  +{session.task_ids.length - 2}
+                                </Badge>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-3 py-2">
+                            <div className="flex flex-wrap gap-1">
+                              {visibleKeys.map((key) => (
+                                <Badge key={key} variant="outline" className="text-xs">
+                                  {key}
+                                </Badge>
+                              ))}
+                              {remaining > 0 && (
+                                <span className="text-xs text-muted-foreground">+{remaining} more</span>
+                              )}
+                            </div>
+                          </td>
+                          <td className="px-3 py-2">
+                            {session.updated_at ? new Date(session.updated_at).toLocaleString() : '—'}
+                          </td>
+                        </tr>
+                      )
+                    })
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export default SessionsPage


### PR DESCRIPTION
### Motivation
- Provide a way to inspect session storage from the home UI using the server's session APIs.
- Allow filtering of sessions by thread id and task id to aid debugging and exploration of runs.
- Reuse authenticated fetch logic across home views to ensure requests include the `Authorization` header.
- Surface task associations for each session so the UI can show related runs.

### Description
- Added a `SessionSummary` type and a `list_sessions` method to the `SessionStore` trait to enumerate available sessions with metadata.
- Implemented `list_sessions` for the Diesel-backed store and the local in-memory `LocalSessionStore`, including updated timestamps and key counts.
- Exposed a new API `GET /api/v1/session` (implemented in `server/distri-server/src/routes/session.rs`) that returns session summaries and can be filtered by `thread_id` and `task_id`, and enriches results with related task IDs via the task store.
- Added a shared `useHomeFetch` hook and a new `SessionsPage` UI under `/home/sessions`, updated `useHomeStats` to use the shared fetch, and added the Sessions entry to the home sidebar and router.

### Testing
- Attempted to run the UI dev server with `pnpm -C /workspace/distri/distri-ui dev`, but it failed because `vite` was not available in the environment (no `node_modules` installed), so the UI was not exercised end-to-end.
- No automated backend or unit tests were executed in this environment after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f748c316883319c5ee00cd5b625fc)