### PR TITLE
feat: add notes store with markdown indexing, search, and AI summaris…

### DIFF
--- a/distri-ui/src/App.tsx
+++ b/distri-ui/src/App.tsx
@@ -19,6 +19,7 @@ import AgentsPage from './routes/home/AgentsPage';
 import NewAgentPage from './routes/home/NewAgentPage';
 import { Toaster } from './components/ui/sonner';
 import ChatPage from './routes/home/ChatPage';
+import NotesPage from './routes/home/NotesPage';
 
 // Wrapper components to pass props from router to @distri/home components
 function HomePageWrapper() {
@@ -131,6 +132,7 @@ function App() {
                   <Route path="agents" element={<AgentsPage />} />
                   <Route path="new" element={<NewAgentPage />} />
                   <Route path="chat" element={<ChatPage />} />
+                  <Route path="notes" element={<NotesPage />} />
                 </Route>
                 <Route path="workspace" element={<FilesPage />} />
 

--- a/distri-ui/src/components/AppSidebar.tsx
+++ b/distri-ui/src/components/AppSidebar.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   Github,
   Loader2,
+  FileText,
 } from "lucide-react";
 import Logo from "@/assets/logo_small.svg";
 import {
@@ -142,13 +143,13 @@ const ThreadItem: React.FC<ThreadItemProps> = ({
 
 interface AppSidebarProps {
   selectedThreadId: string;
-  currentPage: "chat" | "agents";
+  currentPage: "chat" | "agents" | "notes";
   onNewChat: () => void;
   onThreadSelect: (threadId: string) => void;
   onThreadDelete: (threadId: string) => void;
   onThreadRename: (threadId: string, newTitle: string) => void;
   onLogoClick?: () => void;
-  onPageChange: (page: "chat" | "agents") => void;
+  onPageChange: (page: "chat" | "agents" | "notes") => void;
 }
 
 export function AppSidebar({
@@ -233,6 +234,15 @@ export function AppSidebar({
                 >
                   <Users className="h-4 w-4" />
                   Agents
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem className="mb-1">
+                <SidebarMenuButton
+                  isActive={currentPage === "notes"}
+                  onClick={() => onPageChange("notes")}
+                >
+                  <FileText className="h-4 w-4" />
+                  Notes
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>

--- a/distri-ui/src/layouts/HomeLayout.tsx
+++ b/distri-ui/src/layouts/HomeLayout.tsx
@@ -19,13 +19,14 @@ import {
   SidebarSeparator,
 } from '@/components/ui/sidebar'
 
-import { Settings, Users, Home, MessageSquare, History, FileText } from 'lucide-react'
+import { Settings, Users, Home, MessageSquare, History, FileText, StickyNote } from 'lucide-react'
 import { useAccount } from '@/components/AccountProvider'
 
 const navItems = [
   { id: 'home', label: 'Home', href: '/home', icon: Home },
   { id: 'agents', label: 'Agents', href: '/home/agents', icon: Users },
   { id: 'threads', label: 'Threads', href: '/home/threads', icon: MessageSquare },
+  { id: 'notes', label: 'Notes', href: '/home/notes', icon: StickyNote },
   { id: 'templates', label: 'Templates', href: '/home/templates', icon: FileText },
   { id: 'sessions', label: 'Sessions', href: '/home/sessions', icon: History },
   { id: 'settings', label: 'Settings', href: '/home/settings', icon: Settings },

--- a/distri-ui/src/routes/home/NotesPage.tsx
+++ b/distri-ui/src/routes/home/NotesPage.tsx
@@ -1,0 +1,516 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { BACKEND_URL } from '@/constants'
+import { useInitialization } from '@/components/TokenProvider'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog'
+import {
+  Search,
+  Plus,
+  Trash2,
+  ArrowLeft,
+  FileText,
+  Tag,
+  RefreshCw,
+  Calendar,
+  Loader2,
+} from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+
+interface NoteRecord {
+  id: string
+  user_id: string
+  title: string
+  content: string
+  summary: string
+  tags: string[]
+  headings: string[]
+  keywords: string[]
+  created_at: string
+  updated_at: string
+}
+
+interface NoteListResponse {
+  notes: NoteRecord[]
+  total: number
+}
+
+function useAuthHeaders() {
+  const { token } = useInitialization()
+  return useMemo(() => {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+    return headers
+  }, [token])
+}
+
+export default function NotesPage() {
+  const [notes, setNotes] = useState<NoteRecord[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedNote, setSelectedNote] = useState<NoteRecord | null>(null)
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [newTitle, setNewTitle] = useState('')
+  const [newContent, setNewContent] = useState('')
+  const [newTags, setNewTags] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [tagFilter, setTagFilter] = useState<string | null>(null)
+  const [editMode, setEditMode] = useState(false)
+  const [editContent, setEditContent] = useState('')
+  const [editTitle, setEditTitle] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [summarising, setSummarising] = useState(false)
+  const headers = useAuthHeaders()
+
+  const fetchNotes = useCallback(async () => {
+    setLoading(true)
+    try {
+      let response: Response
+
+      if (searchQuery.trim() || tagFilter) {
+        const body: Record<string, unknown> = {}
+        if (searchQuery.trim()) body.query = searchQuery.trim()
+        if (tagFilter) body.tags = [tagFilter]
+
+        response = await fetch(`${BACKEND_URL}/v1/notes/search`, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        })
+      } else {
+        response = await fetch(`${BACKEND_URL}/v1/notes?limit=100`, { headers })
+      }
+
+      if (response.ok) {
+        const data: NoteListResponse = await response.json()
+        setNotes(data.notes)
+        setTotal(data.total)
+      }
+    } catch (err) {
+      console.error('Failed to fetch notes:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [searchQuery, tagFilter, headers])
+
+  useEffect(() => {
+    fetchNotes()
+  }, [fetchNotes])
+
+  const handleCreate = async () => {
+    if (!newTitle.trim()) return
+    setCreating(true)
+    try {
+      const tags = newTags
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+      const response = await fetch(`${BACKEND_URL}/v1/notes`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          title: newTitle.trim(),
+          content: newContent,
+          tags,
+        }),
+      })
+
+      if (response.ok) {
+        setShowCreateDialog(false)
+        setNewTitle('')
+        setNewContent('')
+        setNewTags('')
+        fetchNotes()
+      }
+    } catch (err) {
+      console.error('Failed to create note:', err)
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    try {
+      const response = await fetch(`${BACKEND_URL}/v1/notes/${id}`, {
+        method: 'DELETE',
+        headers,
+      })
+      if (response.ok) {
+        if (selectedNote?.id === id) {
+          setSelectedNote(null)
+        }
+        fetchNotes()
+      }
+    } catch (err) {
+      console.error('Failed to delete note:', err)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!selectedNote) return
+    setSaving(true)
+    try {
+      const body: Record<string, unknown> = {}
+      if (editTitle !== selectedNote.title) body.title = editTitle
+      if (editContent !== selectedNote.content) body.content = editContent
+
+      const response = await fetch(`${BACKEND_URL}/v1/notes/${selectedNote.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(body),
+      })
+      if (response.ok) {
+        const updated: NoteRecord = await response.json()
+        setSelectedNote(updated)
+        setEditMode(false)
+        fetchNotes()
+      }
+    } catch (err) {
+      console.error('Failed to save note:', err)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSummarise = async (id: string) => {
+    setSummarising(true)
+    try {
+      const response = await fetch(`${BACKEND_URL}/v1/notes/${id}/summarise`, {
+        method: 'POST',
+        headers,
+      })
+      if (response.ok) {
+        const updated: NoteRecord = await response.json()
+        setSelectedNote(updated)
+        fetchNotes()
+      }
+    } catch (err) {
+      console.error('Failed to summarise note:', err)
+    } finally {
+      setSummarising(false)
+    }
+  }
+
+  // Collect all unique tags across notes
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>()
+    notes.forEach((n) => n.tags.forEach((t) => tagSet.add(t)))
+    return Array.from(tagSet).sort()
+  }, [notes])
+
+  const formatDate = (dateStr: string) => {
+    const d = new Date(dateStr)
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+  }
+
+  // Detail view for a selected note
+  if (selectedNote) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex items-center gap-2 p-4 border-b">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setSelectedNote(null)
+              setEditMode(false)
+            }}
+          >
+            <ArrowLeft className="h-4 w-4 mr-1" />
+            Back
+          </Button>
+          <div className="flex-1" />
+          {!editMode && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  setEditTitle(selectedNote.title)
+                  setEditContent(selectedNote.content)
+                  setEditMode(true)
+                }}
+              >
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleSummarise(selectedNote.id)}
+                disabled={summarising}
+              >
+                {summarising ? (
+                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                ) : (
+                  <RefreshCw className="h-3 w-3 mr-1" />
+                )}
+                Summarise
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => handleDelete(selectedNote.id)}
+              >
+                <Trash2 className="h-3 w-3 mr-1" />
+                Delete
+              </Button>
+            </>
+          )}
+          {editMode && (
+            <>
+              <Button variant="ghost" size="sm" onClick={() => setEditMode(false)}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleSave} disabled={saving}>
+                {saving && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+                Save
+              </Button>
+            </>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-auto p-6">
+          {editMode ? (
+            <div className="space-y-4 max-w-4xl">
+              <Input
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+                className="text-xl font-bold"
+                placeholder="Note title"
+              />
+              <Textarea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                className="min-h-[400px] font-mono text-sm"
+                placeholder="Write your markdown note..."
+              />
+            </div>
+          ) : (
+            <div className="max-w-4xl">
+              <h1 className="text-2xl font-bold mb-2">{selectedNote.title}</h1>
+
+              <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+                <Calendar className="h-3 w-3" />
+                <span>Created {formatDate(selectedNote.created_at)}</span>
+                <span className="mx-1">|</span>
+                <span>Updated {formatDate(selectedNote.updated_at)}</span>
+              </div>
+
+              {selectedNote.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mb-4">
+                  {selectedNote.tags.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="text-xs">
+                      <Tag className="h-2.5 w-2.5 mr-1" />
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              )}
+
+              {selectedNote.summary && (
+                <Card className="mb-4">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm">Summary</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">{selectedNote.summary}</p>
+                  </CardContent>
+                </Card>
+              )}
+
+              {selectedNote.headings.length > 0 && (
+                <Card className="mb-4">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-sm">Table of Contents</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="text-sm space-y-1">
+                      {selectedNote.headings.map((h, i) => (
+                        <li key={i} className="text-muted-foreground">
+                          {h}
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              )}
+
+              <div className="prose prose-sm dark:prose-invert max-w-none">
+                <ReactMarkdown>{selectedNote.content}</ReactMarkdown>
+              </div>
+
+              {selectedNote.keywords.length > 0 && (
+                <div className="mt-6 pt-4 border-t">
+                  <p className="text-xs text-muted-foreground mb-2">Keywords</p>
+                  <div className="flex flex-wrap gap-1">
+                    {selectedNote.keywords.map((kw) => (
+                      <Badge key={kw} variant="outline" className="text-xs">
+                        {kw}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // List view
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-3 p-4 border-b">
+        <div className="flex items-center gap-2">
+          <FileText className="h-5 w-5" />
+          <h2 className="text-lg font-semibold">Notes</h2>
+          <Badge variant="secondary" className="text-xs">
+            {total}
+          </Badge>
+        </div>
+        <div className="flex-1" />
+        <div className="relative w-64">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search notes..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-8"
+          />
+        </div>
+        <Button size="sm" onClick={() => setShowCreateDialog(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          New Note
+        </Button>
+      </div>
+
+      {/* Tag filters */}
+      {allTags.length > 0 && (
+        <div className="flex flex-wrap gap-1 px-4 py-2 border-b">
+          <Button
+            variant={tagFilter === null ? 'default' : 'outline'}
+            size="sm"
+            className="h-6 text-xs"
+            onClick={() => setTagFilter(null)}
+          >
+            All
+          </Button>
+          {allTags.map((tag) => (
+            <Button
+              key={tag}
+              variant={tagFilter === tag ? 'default' : 'outline'}
+              size="sm"
+              className="h-6 text-xs"
+              onClick={() => setTagFilter(tagFilter === tag ? null : tag)}
+            >
+              {tag}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {/* Notes grid */}
+      <div className="flex-1 overflow-auto p-4">
+        {loading ? (
+          <div className="flex items-center justify-center h-32">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : notes.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
+            <FileText className="h-8 w-8 mb-2" />
+            <p>{searchQuery || tagFilter ? 'No notes match your search' : 'No notes yet'}</p>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {notes.map((note) => (
+              <Card
+                key={note.id}
+                className="cursor-pointer hover:border-primary/50 transition-colors"
+                onClick={() => setSelectedNote(note)}
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm truncate">{note.title}</CardTitle>
+                  <CardDescription className="text-xs">
+                    {formatDate(note.updated_at)}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {note.summary ? (
+                    <p className="text-xs text-muted-foreground line-clamp-2">{note.summary}</p>
+                  ) : (
+                    <p className="text-xs text-muted-foreground line-clamp-2">
+                      {note.content.slice(0, 150)}
+                    </p>
+                  )}
+                  {note.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {note.tags.slice(0, 3).map((tag) => (
+                        <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+                          {tag}
+                        </Badge>
+                      ))}
+                      {note.tags.length > 3 && (
+                        <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+                          +{note.tags.length - 3}
+                        </Badge>
+                      )}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Create Note Dialog */}
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Create Note</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              placeholder="Note title"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+            />
+            <Textarea
+              placeholder="Write your markdown note content..."
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              className="min-h-[250px] font-mono text-sm"
+            />
+            <Input
+              placeholder="Tags (comma-separated, e.g. meeting-notes, project-x)"
+              value={newTags}
+              onChange={(e) => setNewTags(e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setShowCreateDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={!newTitle.trim() || creating}>
+              {creating && <Loader2 className="h-3 w-3 animate-spin mr-1" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/server/agents/notes_summariser.md
+++ b/server/agents/notes_summariser.md
@@ -1,0 +1,25 @@
+---
+name = "notes_summariser"
+description = "Analyses markdown notes and generates summaries, tags, keywords, and headings for indexing"
+version = "1.0.0"
+
+[model_settings]
+max_tokens = 1024
+temperature = 0.3
+---
+
+You are a note analysis assistant. Your job is to analyse markdown notes and extract structured metadata for indexing and search.
+
+When given a note, you must return a JSON object with exactly these fields:
+
+- **summary**: A concise 1-3 sentence summary capturing the key points of the note
+- **tags**: An array of relevant topic tags (lowercase, hyphenated, no spaces). Generate 3-8 tags that categorise the note's subject matter
+- **keywords**: An array of 5-15 important keywords or terms from the content that would be useful for search
+- **headings**: An array of all markdown headings found in the note (text only, without # symbols)
+
+Rules:
+- Return ONLY a valid JSON object, no markdown formatting, no explanation
+- Tags should be general enough to group related notes (e.g. "machine-learning", "project-planning", "meeting-notes")
+- Keywords should be specific terms from the content that a user might search for
+- The summary should be informative enough to understand the note without reading it
+- If the note is very short, still provide all fields (use fewer tags/keywords)

--- a/server/distri-server/src/routes.rs
+++ b/server/distri-server/src/routes.rs
@@ -32,6 +32,7 @@ use crate::tts::{get_available_voices, synthesize_tts, transcribe_speech};
 mod artifacts;
 mod files;
 mod llm_helpers;
+mod notes;
 mod prompt_templates;
 mod secrets;
 mod session;
@@ -123,6 +124,7 @@ pub fn distri(cfg: &mut web::ServiceConfig) {
     .service(web::resource("/home/stats").route(web::get().to(get_home_stats)))
     .configure(prompt_templates::configure_prompt_template_routes)
     .configure(secrets::configure_secret_routes)
+    .configure(notes::configure_note_routes)
     // Voice streaming endpoints - TODO: Implement after fixing compilation issues
     // .service(web::resource("/voice/stream").route(web::get().to(voice_stream_handler)));
     // Authentication endpoints

--- a/server/distri-server/src/routes/notes.rs
+++ b/server/distri-server/src/routes/notes.rs
@@ -1,0 +1,381 @@
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse};
+use distri_core::agent::AgentOrchestrator;
+use distri_core::ToolAuthRequestContext;
+use distri_types::stores::{CreateNoteRequest, NoteSearchFilter, UpdateNoteRequest};
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::context::UserContext;
+
+pub fn configure_note_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::resource("/notes")
+            .route(web::get().to(list_notes))
+            .route(web::post().to(create_note)),
+    )
+    .service(web::resource("/notes/search").route(web::post().to(search_notes)))
+    .service(
+        web::resource("/notes/{id}")
+            .route(web::get().to(get_note))
+            .route(web::put().to(update_note))
+            .route(web::delete().to(delete_note)),
+    )
+    .service(web::resource("/notes/{id}/summarise").route(web::post().to(summarise_note)));
+}
+
+fn get_user_id(req: &HttpRequest) -> String {
+    req.extensions()
+        .get::<UserContext>()
+        .map(|ctx: &UserContext| ctx.user_id())
+        .unwrap_or_else(|| "local_dev_user".to_string())
+}
+
+#[derive(Debug, Deserialize)]
+struct ListNotesQuery {
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+async fn list_notes(
+    query: web::Query<ListNotesQuery>,
+    executor: web::Data<Arc<AgentOrchestrator>>,
+    req: HttpRequest,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    let user_id = get_user_id(&req);
+
+    match store
+        .list_notes(&user_id, query.limit, query.offset)
+        .await
+    {
+        Ok(response) => HttpResponse::Ok().json(response),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn create_note(
+    executor: web::Data<Arc<AgentOrchestrator>>,
+    payload: web::Json<CreateNoteRequest>,
+    req: HttpRequest,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    let user_id = get_user_id(&req);
+
+    match store.create_note(&user_id, payload.into_inner()).await {
+        Ok(note) => {
+            // Trigger async summarisation via notes_summariser agent
+            let note_id = note.id.clone();
+            let orchestrator = executor.get_ref().clone();
+            tokio::spawn(async move {
+                if let Err(e) = trigger_note_summarisation(&orchestrator, &note_id).await {
+                    tracing::warn!("Failed to trigger note summarisation for {}: {}", note_id, e);
+                }
+            });
+
+            HttpResponse::Ok().json(note)
+        }
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn get_note(
+    id: web::Path<String>,
+    executor: web::Data<Arc<AgentOrchestrator>>,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    match store.get_note(&id).await {
+        Ok(Some(note)) => HttpResponse::Ok().json(note),
+        Ok(None) => HttpResponse::NotFound().json(json!({"error": "Note not found"})),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn update_note(
+    id: web::Path<String>,
+    executor: web::Data<Arc<AgentOrchestrator>>,
+    payload: web::Json<UpdateNoteRequest>,
+    _req: HttpRequest,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    let note_id = id.into_inner();
+    let has_content_change = payload.content.is_some();
+
+    match store.update_note(&note_id, payload.into_inner()).await {
+        Ok(note) => {
+            // Re-summarise if content changed
+            if has_content_change {
+                let orchestrator = executor.get_ref().clone();
+                let nid = note.id.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = trigger_note_summarisation(&orchestrator, &nid).await {
+                        tracing::warn!(
+                            "Failed to trigger note re-summarisation for {}: {}",
+                            nid,
+                            e
+                        );
+                    }
+                });
+            }
+            HttpResponse::Ok().json(note)
+        }
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn delete_note(
+    id: web::Path<String>,
+    executor: web::Data<Arc<AgentOrchestrator>>,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    match store.delete_note(&id).await {
+        Ok(_) => HttpResponse::NoContent().finish(),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": e.to_string()})),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchNotesRequest {
+    #[serde(flatten)]
+    filter: NoteSearchFilter,
+    limit: Option<u32>,
+    offset: Option<u32>,
+}
+
+async fn search_notes(
+    executor: web::Data<Arc<AgentOrchestrator>>,
+    payload: web::Json<SearchNotesRequest>,
+    req: HttpRequest,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    let user_id = get_user_id(&req);
+    let search = payload.into_inner();
+
+    match store
+        .search_notes(&user_id, &search.filter, search.limit, search.offset)
+        .await
+    {
+        Ok(response) => HttpResponse::Ok().json(response),
+        Err(e) => HttpResponse::InternalServerError().json(json!({"error": e.to_string()})),
+    }
+}
+
+async fn summarise_note(
+    id: web::Path<String>,
+    executor: web::Data<Arc<AgentOrchestrator>>,
+    req: HttpRequest,
+) -> HttpResponse {
+    let store = match &executor.stores.note_store {
+        Some(s) => s,
+        None => {
+            return HttpResponse::InternalServerError()
+                .json(json!({"error": "Note store not initialized"}))
+        }
+    };
+
+    let note_id = id.into_inner();
+    let _user_id = get_user_id(&req);
+
+    // Verify note exists
+    match store.get_note(&note_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return HttpResponse::NotFound().json(json!({"error": "Note not found"})),
+        Err(e) => {
+            return HttpResponse::InternalServerError().json(json!({"error": e.to_string()}))
+        }
+    }
+
+    match trigger_note_summarisation(executor.get_ref(), &note_id).await {
+        Ok(_) => {
+            // Return the updated note
+            match store.get_note(&note_id).await {
+                Ok(Some(note)) => HttpResponse::Ok().json(note),
+                Ok(None) => {
+                    HttpResponse::NotFound().json(json!({"error": "Note not found after update"}))
+                }
+                Err(e) => {
+                    HttpResponse::InternalServerError().json(json!({"error": e.to_string()}))
+                }
+            }
+        }
+        Err(e) => HttpResponse::InternalServerError()
+            .json(json!({"error": format!("Summarisation failed: {}", e)})),
+    }
+}
+
+/// Trigger summarisation of a note using the notes_summariser agent via LLM execute
+async fn trigger_note_summarisation(
+    orchestrator: &Arc<AgentOrchestrator>,
+    note_id: &str,
+) -> anyhow::Result<()> {
+    let store = orchestrator
+        .stores
+        .note_store
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Note store not initialized"))?;
+
+    let note = store
+        .get_note(note_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Note not found: {}", note_id))?;
+
+    // Use the LLM service to summarise
+    let service = distri_core::llm_service::LlmExecuteService::new(orchestrator.clone());
+
+    let prompt = format!(
+        "Analyse the following markdown note and return a JSON object with these fields:\n\
+         - \"summary\": A concise 1-3 sentence summary of the note\n\
+         - \"tags\": An array of relevant topic tags (lowercase, no spaces, use hyphens)\n\
+         - \"keywords\": An array of important keywords from the content\n\
+         - \"headings\": An array of all headings found in the markdown\n\n\
+         Return ONLY the JSON object, no markdown formatting or explanation.\n\n\
+         Note title: {}\n\n\
+         Note content:\n{}",
+        note.title, note.content
+    );
+
+    let mut message = distri_types::Message::default();
+    message.role = distri_types::MessageRole::User;
+    message.parts = vec![distri_types::Part::Text(prompt)];
+
+    let messages = vec![message];
+
+    let model_settings = orchestrator.get_default_model_settings().await;
+
+    let result = service
+        .execute(
+            "system".to_string(),
+            None,
+            "notes_summariser".to_string(),
+            None,
+            None,
+            None,
+            messages,
+            vec![],
+            model_settings,
+            None,
+            Some(format!("Summarise: {}", note.title)),
+            None,
+            true,
+        )
+        .await;
+
+    match result {
+        Ok(exec_result) => {
+            // LLMResponse.content is a String
+            let response_text = &exec_result.response.content;
+
+            // Try to extract JSON from the response (handle markdown code blocks)
+            let json_str = response_text
+                .trim()
+                .trim_start_matches("```json")
+                .trim_start_matches("```")
+                .trim_end_matches("```")
+                .trim();
+
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str) {
+                let summary = parsed
+                    .get("summary")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let tags: Vec<String> = parsed
+                    .get("tags")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let keywords: Vec<String> = parsed
+                    .get("keywords")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let headings: Vec<String> = parsed
+                    .get("headings")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                // Merge existing tags with generated tags
+                let mut all_tags = note.tags.clone();
+                for tag in &tags {
+                    if !all_tags
+                        .iter()
+                        .any(|t| t.to_lowercase() == tag.to_lowercase())
+                    {
+                        all_tags.push(tag.clone());
+                    }
+                }
+
+                store
+                    .update_note_index(note_id, &summary, headings, keywords, all_tags)
+                    .await?;
+                tracing::info!("Note {} summarised successfully", note_id);
+            } else {
+                tracing::warn!(
+                    "Failed to parse summarisation response as JSON for note {}: {}",
+                    note_id,
+                    json_str
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!("LLM summarisation call failed for note {}: {}", note_id, e);
+        }
+    }
+
+    Ok(())
+}

--- a/server/distri-stores/src/diesel_store/mod.rs
+++ b/server/distri-stores/src/diesel_store/mod.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, fmt::Display, sync::Arc};
 use crate::models::*;
 use crate::schema::{
     agent_configs, external_tool_calls, integrations, memory_entries, message_reads, message_votes,
-    plugin_catalog, scratchpad_entries, session_entries, task_messages, tasks, threads,
+    notes, plugin_catalog, scratchpad_entries, session_entries, task_messages, tasks, threads,
 };
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
@@ -29,12 +29,13 @@ use distri_types::auth::{AuthError, AuthSecret, AuthSession, OAuth2State, ToolAu
 use distri_types::configuration::PluginArtifact;
 use distri_types::stores::SessionSummary;
 use distri_types::stores::{
-    AgentStatsInfo, AgentStore, AgentUsageInfo, ExternalToolCallsStore, FilterMessageType,
-    MemoryStore, MessageFilter, MessageReadStatus, MessageVote, MessageVoteSummary,
-    NewPromptTemplate, NewSecret, PluginCatalogStore, PluginMetadataRecord, PromptTemplateRecord,
+    AgentStatsInfo, AgentStore, AgentUsageInfo, CreateNoteRequest, ExternalToolCallsStore,
+    FilterMessageType, MemoryStore, MessageFilter, MessageReadStatus, MessageVote,
+    MessageVoteSummary, NewPromptTemplate, NewSecret, NoteListResponse, NoteRecord,
+    NoteSearchFilter, NoteStore, PluginCatalogStore, PluginMetadataRecord, PromptTemplateRecord,
     PromptTemplateStore, ScratchpadStore, SecretRecord, SecretStore, SessionMemory, SessionStore,
-    TaskStore, ThreadListFilter, ThreadListResponse, ThreadStore, UpdatePromptTemplate,
-    VoteMessageRequest, VoteType,
+    TaskStore, ThreadListFilter, ThreadListResponse, ThreadStore, UpdateNoteRequest,
+    UpdatePromptTemplate, VoteMessageRequest, VoteType,
 };
 use distri_types::{
     AgentError, AgentEvent, AgentEventType, CreateThreadRequest, Message, ScratchpadEntry, Task,
@@ -3252,6 +3253,10 @@ where
     pub fn secret_store(&self) -> DieselSecretStore<Conn> {
         DieselSecretStore::new(self.pool.clone_store_pool())
     }
+
+    pub fn note_store(&self) -> DieselNoteStore<Conn> {
+        DieselNoteStore::new(self.pool.clone_store_pool())
+    }
 }
 
 // ========== Prompt Template Store ==========
@@ -3640,6 +3645,385 @@ where
                     .await?;
             }
         }
+
+        Ok(())
+    }
+}
+
+// ========== Note Store ==========
+
+fn to_note_record(model: NoteModel) -> NoteRecord {
+    NoteRecord {
+        id: model.id,
+        user_id: model.user_id,
+        title: model.title,
+        content: model.content,
+        summary: model.summary,
+        tags: serde_json::from_str(&model.tags).unwrap_or_default(),
+        headings: serde_json::from_str(&model.headings).unwrap_or_default(),
+        keywords: serde_json::from_str(&model.keywords).unwrap_or_default(),
+        created_at: from_naive(model.created_at),
+        updated_at: from_naive(model.updated_at),
+    }
+}
+
+/// Extract markdown headings (lines starting with #) from content
+fn extract_headings(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') {
+                Some(trimmed.trim_start_matches('#').trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|h| !h.is_empty())
+        .collect()
+}
+
+/// Extract simple keywords from content by finding significant words
+fn extract_keywords(content: &str) -> Vec<String> {
+    let stop_words: std::collections::HashSet<&str> = [
+        "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for", "of", "with",
+        "by", "from", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had",
+        "do", "does", "did", "will", "would", "could", "should", "may", "might", "can", "shall",
+        "this", "that", "these", "those", "it", "its", "not", "no", "so", "if", "then", "else",
+        "when", "where", "how", "what", "which", "who", "whom", "why", "all", "each", "every",
+        "both", "few", "more", "most", "other", "some", "such", "than", "too", "very", "just",
+        "about", "above", "after", "again", "also", "any", "as", "because", "before", "between",
+    ]
+    .iter()
+    .copied()
+    .collect();
+
+    let mut word_counts: HashMap<String, usize> = HashMap::new();
+    for word in content.split(|c: char| !c.is_alphanumeric()) {
+        let lower = word.to_lowercase();
+        if lower.len() >= 3 && !stop_words.contains(lower.as_str()) {
+            *word_counts.entry(lower).or_insert(0) += 1;
+        }
+    }
+
+    let mut words: Vec<(String, usize)> = word_counts.into_iter().collect();
+    words.sort_by(|a, b| b.1.cmp(&a.1));
+    words.into_iter().take(20).map(|(w, _)| w).collect()
+}
+
+#[derive(Clone)]
+pub struct DieselNoteStore<Conn>
+where
+    Conn: DieselBackendConnection,
+    diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>: ExecuteDsl<Conn>,
+    diesel::query_builder::SqlQuery: QueryFragment<<Conn as AsyncConnectionCore>::Backend>,
+    <Conn as AsyncConnectionCore>::Backend: diesel::backend::DieselReserveSpecialization,
+{
+    pool: DieselStorePool<Conn>,
+}
+
+impl<Conn> DieselNoteStore<Conn>
+where
+    Conn: DieselBackendConnection,
+    diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>: ExecuteDsl<Conn>,
+    diesel::query_builder::SqlQuery: QueryFragment<<Conn as AsyncConnectionCore>::Backend>,
+    <Conn as AsyncConnectionCore>::Backend: diesel::backend::DieselReserveSpecialization,
+{
+    pub fn new(pool: DieselStorePool<Conn>) -> Self {
+        Self { pool }
+    }
+
+    async fn conn(&self) -> Result<DieselConn<'_, Conn>> {
+        self.pool
+            .get()
+            .await
+            .context("failed to acquire diesel connection for notes")
+    }
+}
+
+#[async_trait]
+impl<Conn> NoteStore for DieselNoteStore<Conn>
+where
+    Conn: DieselBackendConnection,
+    diesel::dsl::select<diesel::dsl::AsExprOf<i32, diesel::sql_types::Integer>>: ExecuteDsl<Conn>,
+    diesel::query_builder::SqlQuery: QueryFragment<<Conn as AsyncConnectionCore>::Backend>,
+    <Conn as AsyncConnectionCore>::Backend: diesel::backend::DieselReserveSpecialization,
+{
+    async fn create_note(
+        &self,
+        user_id: &str,
+        request: CreateNoteRequest,
+    ) -> Result<NoteRecord> {
+        let mut conn = self.conn().await?;
+        let now = now_naive();
+        let new_id = Uuid::new_v4().to_string();
+
+        let headings = extract_headings(&request.content);
+        let keywords = extract_keywords(&request.content);
+        let tags_json = serde_json::to_string(&request.tags).unwrap_or_else(|_| "[]".to_string());
+        let headings_json =
+            serde_json::to_string(&headings).unwrap_or_else(|_| "[]".to_string());
+        let keywords_json =
+            serde_json::to_string(&keywords).unwrap_or_else(|_| "[]".to_string());
+
+        let model = NewNoteModel {
+            id: &new_id,
+            user_id,
+            title: &request.title,
+            content: &request.content,
+            summary: "",
+            tags: &tags_json,
+            headings: &headings_json,
+            keywords: &keywords_json,
+            created_at: now,
+            updated_at: now,
+        };
+
+        diesel::insert_into(notes::table)
+            .values(&model)
+            .execute(&mut conn)
+            .await
+            .context("failed to insert note")?;
+
+        let result = notes::table
+            .filter(notes::id.eq(&new_id))
+            .select(NoteModel::as_select())
+            .first::<NoteModel>(&mut conn)
+            .await
+            .context("failed to retrieve created note")?;
+
+        Ok(to_note_record(result))
+    }
+
+    async fn get_note(&self, note_id: &str) -> Result<Option<NoteRecord>> {
+        let mut conn = self.conn().await?;
+        let result = notes::table
+            .filter(notes::id.eq(note_id))
+            .select(NoteModel::as_select())
+            .first::<NoteModel>(&mut conn)
+            .await
+            .optional()
+            .context("failed to get note")?;
+
+        Ok(result.map(to_note_record))
+    }
+
+    async fn update_note(
+        &self,
+        note_id: &str,
+        request: UpdateNoteRequest,
+    ) -> Result<NoteRecord> {
+        let mut conn = self.conn().await?;
+        let now = now_naive();
+
+        // Build changeset fields
+        let title_str = request.title;
+        let content_str = request.content.clone();
+
+        // Re-index if content changed
+        let headings_json = request.content.as_ref().map(|c| {
+            let h = extract_headings(c);
+            serde_json::to_string(&h).unwrap_or_else(|_| "[]".to_string())
+        });
+        let keywords_json = request.content.as_ref().map(|c| {
+            let k = extract_keywords(c);
+            serde_json::to_string(&k).unwrap_or_else(|_| "[]".to_string())
+        });
+        let tags_json = request.tags.as_ref().map(|t| {
+            serde_json::to_string(t).unwrap_or_else(|_| "[]".to_string())
+        });
+
+        let changeset = NoteChangeset {
+            title: title_str.as_deref(),
+            content: content_str.as_deref(),
+            tags: tags_json.as_deref(),
+            headings: headings_json.as_deref(),
+            keywords: keywords_json.as_deref(),
+            summary: None,
+            updated_at: now,
+        };
+
+        diesel::update(notes::table.filter(notes::id.eq(note_id)))
+            .set(&changeset)
+            .execute(&mut conn)
+            .await
+            .context("failed to update note")?;
+
+        let result = notes::table
+            .filter(notes::id.eq(note_id))
+            .select(NoteModel::as_select())
+            .first::<NoteModel>(&mut conn)
+            .await
+            .context("failed to retrieve updated note")?;
+
+        Ok(to_note_record(result))
+    }
+
+    async fn delete_note(&self, note_id: &str) -> Result<()> {
+        let mut conn = self.conn().await?;
+        diesel::delete(notes::table.filter(notes::id.eq(note_id)))
+            .execute(&mut conn)
+            .await
+            .context("failed to delete note")?;
+        Ok(())
+    }
+
+    async fn search_notes(
+        &self,
+        user_id: &str,
+        filter: &NoteSearchFilter,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<NoteListResponse> {
+        let mut conn = self.conn().await?;
+        let limit = limit.unwrap_or(50) as i64;
+        let offset = offset.unwrap_or(0) as i64;
+
+        // Load all user notes and filter in-memory for flexible search
+        let all_notes = notes::table
+            .filter(notes::user_id.eq(user_id))
+            .order(notes::updated_at.desc())
+            .load::<NoteModel>(&mut conn)
+            .await
+            .context("failed to load notes for search")?;
+
+        let filtered: Vec<NoteModel> = all_notes
+            .into_iter()
+            .filter(|note| {
+                // Full-text search
+                if let Some(ref query) = filter.query {
+                    let q = query.to_lowercase();
+                    let matches = note.title.to_lowercase().contains(&q)
+                        || note.content.to_lowercase().contains(&q)
+                        || note.headings.to_lowercase().contains(&q)
+                        || note.keywords.to_lowercase().contains(&q)
+                        || note.summary.to_lowercase().contains(&q);
+                    if !matches {
+                        return false;
+                    }
+                }
+
+                // Tag filter
+                if let Some(ref tags) = filter.tags {
+                    let note_tags: Vec<String> =
+                        serde_json::from_str(&note.tags).unwrap_or_default();
+                    for tag in tags {
+                        if !note_tags
+                            .iter()
+                            .any(|t| t.to_lowercase() == tag.to_lowercase())
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                // Heading filter
+                if let Some(ref heading) = filter.heading {
+                    let h = heading.to_lowercase();
+                    if !note.headings.to_lowercase().contains(&h) {
+                        return false;
+                    }
+                }
+
+                // Date filters
+                if let Some(ref from) = filter.from_date {
+                    if from_naive(note.created_at) < *from {
+                        return false;
+                    }
+                }
+                if let Some(ref to) = filter.to_date {
+                    if from_naive(note.created_at) > *to {
+                        return false;
+                    }
+                }
+
+                true
+            })
+            .collect();
+
+        let total = filtered.len() as i64;
+
+        // Apply pagination
+        let start = offset as usize;
+        let end = std::cmp::min(start + limit as usize, filtered.len());
+        let page = if start < filtered.len() {
+            filtered[start..end].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        Ok(NoteListResponse {
+            notes: page.into_iter().map(to_note_record).collect(),
+            total,
+        })
+    }
+
+    async fn list_notes(
+        &self,
+        user_id: &str,
+        limit: Option<u32>,
+        offset: Option<u32>,
+    ) -> Result<NoteListResponse> {
+        let mut conn = self.conn().await?;
+        let limit_val = limit.unwrap_or(50) as i64;
+        let offset_val = offset.unwrap_or(0) as i64;
+
+        // Get total count
+        let all_notes = notes::table
+            .filter(notes::user_id.eq(user_id))
+            .load::<NoteModel>(&mut conn)
+            .await
+            .context("failed to count notes")?;
+        let total = all_notes.len() as i64;
+
+        // Get paginated results
+        let results = notes::table
+            .filter(notes::user_id.eq(user_id))
+            .order(notes::updated_at.desc())
+            .limit(limit_val)
+            .offset(offset_val)
+            .load::<NoteModel>(&mut conn)
+            .await
+            .context("failed to list notes")?;
+
+        Ok(NoteListResponse {
+            notes: results.into_iter().map(to_note_record).collect(),
+            total,
+        })
+    }
+
+    async fn update_note_index(
+        &self,
+        note_id: &str,
+        summary: &str,
+        headings: Vec<String>,
+        keywords: Vec<String>,
+        tags: Vec<String>,
+    ) -> Result<()> {
+        let mut conn = self.conn().await?;
+        let now = now_naive();
+
+        let headings_json =
+            serde_json::to_string(&headings).unwrap_or_else(|_| "[]".to_string());
+        let keywords_json =
+            serde_json::to_string(&keywords).unwrap_or_else(|_| "[]".to_string());
+        let tags_json = serde_json::to_string(&tags).unwrap_or_else(|_| "[]".to_string());
+
+        let changeset = NoteChangeset {
+            title: None,
+            content: None,
+            tags: Some(&tags_json),
+            headings: Some(&headings_json),
+            keywords: Some(&keywords_json),
+            summary: Some(summary),
+            updated_at: now,
+        };
+
+        diesel::update(notes::table.filter(notes::id.eq(note_id)))
+            .set(&changeset)
+            .execute(&mut conn)
+            .await
+            .context("failed to update note index")?;
 
         Ok(())
     }

--- a/server/distri-stores/src/initialize.rs
+++ b/server/distri-stores/src/initialize.rs
@@ -32,6 +32,7 @@ pub trait StoreFactory: Send + Sync {
     fn plugin_catalog_store(&self) -> Arc<dyn PluginCatalogStore>;
     fn prompt_template_store(&self) -> Arc<dyn PromptTemplateStore>;
     fn secret_store(&self) -> Arc<dyn SecretStore>;
+    fn note_store(&self) -> Arc<dyn NoteStore>;
 }
 
 impl<Conn> StoreFactory for DieselStoreBuilder<Conn>
@@ -83,6 +84,10 @@ where
     fn secret_store(&self) -> Arc<dyn SecretStore> {
         Arc::new(DieselStoreBuilder::secret_store(self)) as Arc<dyn SecretStore>
     }
+
+    fn note_store(&self) -> Arc<dyn NoteStore> {
+        Arc::new(DieselStoreBuilder::note_store(self)) as Arc<dyn NoteStore>
+    }
 }
 
 fn boxed_initializer<F, Fut, Factory>(initializer: F) -> StoreInitializer
@@ -119,6 +124,7 @@ pub struct StoreBuilder {
     pub plugin_store: Option<Arc<dyn PluginCatalogStore>>,
     pub prompt_template_store: Option<Arc<dyn PromptTemplateStore>>,
     pub secret_store: Option<Arc<dyn SecretStore>>,
+    pub note_store: Option<Arc<dyn NoteStore>>,
 }
 
 impl StoreBuilder {
@@ -138,6 +144,7 @@ impl StoreBuilder {
             plugin_store: None,
             prompt_template_store: None,
             secret_store: None,
+            note_store: None,
         }
         .register_default_store_types()
     }
@@ -268,6 +275,10 @@ impl StoreBuilder {
             .secret_store
             .clone()
             .unwrap_or_else(|| metadata_factory.secret_store());
+        let note_store = self
+            .note_store
+            .clone()
+            .unwrap_or_else(|| metadata_factory.note_store());
 
         // Initialize memory store if configured and not provided
         let memory_store = if let Some(store) = self.memory_store.clone() {
@@ -359,6 +370,7 @@ impl StoreBuilder {
             plugin_store,
             prompt_template_store: Some(prompt_template_store),
             secret_store: Some(secret_store),
+            note_store: Some(note_store),
             plugin_tool_loader: None, // Cloud deployments set this separately
         })
     }
@@ -468,6 +480,7 @@ pub async fn create_ephemeral_execution_stores(
         plugin_store: base_stores.plugin_store.clone(),
         prompt_template_store: base_stores.prompt_template_store.clone(),
         secret_store: base_stores.secret_store.clone(),
+        note_store: base_stores.note_store.clone(),
         plugin_tool_loader: base_stores.plugin_tool_loader.clone(),
     })
 }
@@ -512,6 +525,7 @@ pub async fn prepare_stores_for_execution(
         plugin_store: base_stores.plugin_store.clone(),
         prompt_template_store: base_stores.prompt_template_store.clone(),
         secret_store: base_stores.secret_store.clone(),
+        note_store: base_stores.note_store.clone(),
         plugin_tool_loader: base_stores.plugin_tool_loader.clone(),
     })
 }

--- a/server/distri-stores/src/models.rs
+++ b/server/distri-stores/src/models.rs
@@ -496,3 +496,47 @@ pub struct MessageVoteChangeset<'a> {
     pub comment: Option<Option<&'a str>>,
     pub updated_at: NaiveDateTime,
 }
+
+// ========== Notes ==========
+
+#[derive(Debug, Clone, Queryable, Identifiable, Selectable)]
+#[diesel(table_name = crate::schema::notes)]
+pub struct NoteModel {
+    pub id: String,
+    pub user_id: String,
+    pub title: String,
+    pub content: String,
+    pub summary: String,
+    pub tags: String,
+    pub headings: String,
+    pub keywords: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = crate::schema::notes)]
+pub struct NewNoteModel<'a> {
+    pub id: &'a str,
+    pub user_id: &'a str,
+    pub title: &'a str,
+    pub content: &'a str,
+    pub summary: &'a str,
+    pub tags: &'a str,
+    pub headings: &'a str,
+    pub keywords: &'a str,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, AsChangeset)]
+#[diesel(table_name = crate::schema::notes)]
+pub struct NoteChangeset<'a> {
+    pub title: Option<&'a str>,
+    pub content: Option<&'a str>,
+    pub tags: Option<&'a str>,
+    pub headings: Option<&'a str>,
+    pub keywords: Option<&'a str>,
+    pub summary: Option<&'a str>,
+    pub updated_at: NaiveDateTime,
+}

--- a/server/distri-stores/src/schema.rs
+++ b/server/distri-stores/src/schema.rs
@@ -238,6 +238,23 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+
+    notes (id) {
+        id -> Text,
+        user_id -> Text,
+        title -> Text,
+        content -> Text,
+        summary -> Text,
+        tags -> Text,
+        headings -> Text,
+        keywords -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
 diesel::joinable!(task_messages -> tasks (task_id));
 diesel::joinable!(tasks -> threads (thread_id));
 diesel::joinable!(external_tool_call_events -> external_tool_calls (tool_call_id));
@@ -264,4 +281,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     secrets,
     message_reads,
     message_votes,
+    notes,
 );

--- a/server/migrations/20260207000000_add_notes/down.sql
+++ b/server/migrations/20260207000000_add_notes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS notes;

--- a/server/migrations/20260207000000_add_notes/up.sql
+++ b/server/migrations/20260207000000_add_notes/up.sql
@@ -1,0 +1,17 @@
+-- Notes store: markdown notes with indexing, tags, and summaries
+CREATE TABLE notes (
+    id TEXT PRIMARY KEY NOT NULL,
+    user_id TEXT NOT NULL DEFAULT '',
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    tags TEXT NOT NULL DEFAULT '[]',
+    headings TEXT NOT NULL DEFAULT '[]',
+    keywords TEXT NOT NULL DEFAULT '[]',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_notes_user_id ON notes(user_id);
+CREATE INDEX idx_notes_created_at ON notes(created_at);
+CREATE INDEX idx_notes_updated_at ON notes(updated_at);


### PR DESCRIPTION
…ation

Implements a full-stack notes store that persists markdown files with automatic heading/keyword extraction and LLM-powered summarisation.

Backend:
- Database migration for notes table with tags, headings, keywords, summary
- NoteStore trait with CRUD, search, and index update methods
- DieselNoteStore implementation with in-memory search across all fields
- REST API: GET/POST /notes, POST /notes/search, GET/PUT/DELETE /notes/{id}
- POST /notes/{id}/summarise endpoint for on-demand re-summarisation
- Async summarisation via notes_summariser agent on create/update
- Keyword extraction and heading parsing on save

Frontend:
- NotesPage with card grid view, tag filtering, and full-text search
- Note detail view with markdown rendering, table of contents, and metadata
- Inline edit mode with save functionality
- Create note dialog with tag input
- Summarise button to trigger AI summarisation
- Notes entry in sidebar navigation

Agent:
- notes_summariser agent definition for structured JSON extraction

https://claude.ai/code/session_01HWyGHArp4PPH6sFyjMWBgk