### PR TITLE
Add context compaction event system and tiered compaction strategy

### DIFF
--- a/distri-types/src/events.rs
+++ b/distri-types/src/events.rs
@@ -172,6 +172,36 @@ pub enum AgentEventType {
         action: String,
         todo_count: usize,
     },
+
+    // Context management events
+    ContextCompaction {
+        /// Which tier of compaction was applied
+        tier: CompactionTier,
+        /// Token count before compaction
+        tokens_before: usize,
+        /// Token count after compaction
+        tokens_after: usize,
+        /// Number of entries removed or summarized
+        entries_affected: usize,
+        /// Context budget limit that triggered compaction
+        context_limit: usize,
+        /// Usage ratio that triggered compaction (0.0 - 1.0)
+        usage_ratio: f64,
+        /// Optional summary text (for Tier 2 summarization)
+        summary: Option<String>,
+    },
+}
+
+/// Tier of context compaction applied
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionTier {
+    /// Mechanical: drop old entries, truncate payloads
+    Trim,
+    /// Semantic: LLM-powered summarization of history
+    Summarize,
+    /// Emergency: preserve only essentials
+    Reset,
 }
 
 impl AgentEvent {

--- a/distri-types/src/execution.rs
+++ b/distri-types/src/execution.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::{Part, PlanStep, TaskStatus, ToolResponse, core::FileType};
+use crate::{core::FileType, Part, PlanStep, TaskStatus, ToolResponse};
 
 /// Execution strategy types
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -323,6 +323,23 @@ pub enum ScratchpadEntryType {
     PlanStep(PlanStep),
     #[serde(rename = "execution")]
     Execution(ExecutionHistoryEntry),
+    /// Compressed summary produced by Tier 2 (semantic) compaction
+    #[serde(rename = "summary")]
+    Summary(CompactionSummary),
+}
+
+/// Summary produced by semantic compaction of older scratchpad entries
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompactionSummary {
+    /// LLM-generated summary of compacted history
+    pub summary_text: String,
+    /// Number of entries that were summarized
+    pub entries_summarized: usize,
+    /// Timestamp range of summarized entries
+    pub from_timestamp: i64,
+    pub to_timestamp: i64,
+    /// Token count saved by this compaction
+    pub tokens_saved: usize,
 }
 
 #[cfg(test)]

--- a/distrijs-context-management.patch
+++ b/distrijs-context-management.patch
@@ -1,0 +1,214 @@
+diff --git a/packages/core/src/types.ts b/packages/core/src/types.ts
+index a090fc5..b1c2e3a 100644
+--- a/packages/core/src/types.ts
++++ b/packages/core/src/types.ts
+@@ -183,6 +183,48 @@ export interface DynamicMetadata {
+   dynamic_values?: Record<string, unknown>;
+ }
+
++/**
++ * Tier of context compaction applied by the server.
++ */
++export type CompactionTier = 'trim' | 'summarize' | 'reset';
++
++/**
++ * Emitted when the agent performs context compaction to stay within
++ * token budget limits. Mirrors the server-side ContextCompaction event.
++ */
++export interface ContextCompactionEvent {
++  type: 'context_compaction';
++  /** Which tier of compaction was applied */
++  tier: CompactionTier;
++  /** Token count before compaction */
++  tokens_before: number;
++  /** Token count after compaction */
++  tokens_after: number;
++  /** Number of entries removed or summarized */
++  entries_affected: number;
++  /** Context budget limit that triggered compaction */
++  context_limit: number;
++  /** Usage ratio that triggered compaction (0.0 - 1.0) */
++  usage_ratio: number;
++  /** Optional summary text (for Tier 2 summarization) */
++  summary?: string;
++}
++
++/**
++ * Current context health information derived from compaction events
++ * and usage tracking.
++ */
++export interface ContextHealth {
++  /** Current usage ratio (0.0 - 1.0) */
++  usage_ratio: number;
++  /** Estimated tokens currently used */
++  tokens_used: number;
++  /** Token budget limit */
++  tokens_limit: number;
++  /** Last compaction event, if any */
++  last_compaction?: ContextCompactionEvent;
++}
++
+ /**
+  * Context required for constructing A2A messages from DistriMessage
+  */
+diff --git a/packages/react/src/hooks/useContextHealth.ts b/packages/react/src/hooks/useContextHealth.ts
+new file mode 100644
+index 0000000..e8f1a2c
+--- /dev/null
++++ b/packages/react/src/hooks/useContextHealth.ts
+@@ -0,0 +1,72 @@
++import { useCallback, useEffect, useRef, useState } from 'react';
++import type { ContextCompactionEvent, ContextHealth } from '@distri/core';
++
++/**
++ * Hook that tracks context health by listening for ContextCompaction events
++ * in the agent event stream.
++ *
++ * Usage:
++ * ```tsx
++ * const { contextHealth, lastCompaction, isCompacting } = useContextHealth();
++ * ```
++ *
++ * This hook maintains a running picture of context usage. It updates whenever
++ * a `context_compaction` event is received from the server event stream.
++ */
++export function useContextHealth() {
++  const [contextHealth, setContextHealth] = useState<ContextHealth | null>(null);
++  const [isCompacting, setIsCompacting] = useState(false);
++  const lastCompactionRef = useRef<ContextCompactionEvent | null>(null);
++
++  /**
++   * Process a raw event from the agent stream.
++   * Call this from your event handling loop when you receive task status updates.
++   */
++  const handleEvent = useCallback((event: Record<string, unknown>) => {
++    if (event?.type !== 'context_compaction') return;
++
++    const compactionEvent = event as unknown as ContextCompactionEvent;
++    lastCompactionRef.current = compactionEvent;
++
++    setContextHealth({
++      usage_ratio: compactionEvent.tokens_after / compactionEvent.context_limit,
++      tokens_used: compactionEvent.tokens_after,
++      tokens_limit: compactionEvent.context_limit,
++      last_compaction: compactionEvent,
++    });
++
++    // Brief compacting state for UI transitions
++    setIsCompacting(true);
++    setTimeout(() => setIsCompacting(false), 1500);
++  }, []);
++
++  /**
++   * Reset context health (e.g., on new thread).
++   */
++  const reset = useCallback(() => {
++    setContextHealth(null);
++    lastCompactionRef.current = null;
++    setIsCompacting(false);
++  }, []);
++
++  return {
++    /** Current context health snapshot, or null if no compaction has occurred yet */
++    contextHealth,
++    /** The most recent compaction event */
++    lastCompaction: lastCompactionRef.current,
++    /** Whether a compaction just occurred (true for ~1.5s after event) */
++    isCompacting,
++    /** Call with raw event objects from the stream to update health */
++    handleEvent,
++    /** Reset state (e.g., when switching threads) */
++    reset,
++  };
++}
+diff --git a/packages/react/src/components/ContextIndicator.tsx b/packages/react/src/components/ContextIndicator.tsx
+new file mode 100644
+index 0000000..a3c4d5e
+--- /dev/null
++++ b/packages/react/src/components/ContextIndicator.tsx
+@@ -0,0 +1,69 @@
++import React from 'react';
++import type { ContextHealth } from '@distri/core';
++
++interface ContextIndicatorProps {
++  contextHealth: ContextHealth | null;
++  isCompacting?: boolean;
++  className?: string;
++}
++
++/**
++ * Visual indicator for context window health.
++ *
++ * Shows a progress bar representing context usage and compaction status.
++ * Can be placed in a chat header, sidebar, or status bar.
++ *
++ * Usage:
++ * ```tsx
++ * const { contextHealth, isCompacting } = useContextHealth();
++ * <ContextIndicator contextHealth={contextHealth} isCompacting={isCompacting} />
++ * ```
++ */
++export function ContextIndicator({
++  contextHealth,
++  isCompacting = false,
++  className = '',
++}: ContextIndicatorProps) {
++  if (!contextHealth) return null;
++
++  const percentage = Math.round(contextHealth.usage_ratio * 100);
++  const color = getColor(contextHealth.usage_ratio);
++  const tierLabel = contextHealth.last_compaction?.tier;
++
++  return (
++    <div className={`distri-context-indicator ${className}`} title={`Context: ${percentage}% used`}>
++      <div className="distri-context-bar-bg" style={{ width: '100%', height: 4, background: '#e5e7eb', borderRadius: 2, overflow: 'hidden' }}>
++        <div
++          className="distri-context-bar-fill"
++          style={{
++            width: `${Math.min(percentage, 100)}%`,
++            height: '100%',
++            background: color,
++            borderRadius: 2,
++            transition: 'width 0.5s ease, background 0.3s ease',
++          }}
++        />
++      </div>
++      <div className="distri-context-label" style={{ fontSize: 11, color: '#6b7280', marginTop: 2, display: 'flex', justifyContent: 'space-between' }}>
++        <span>
++          {isCompacting ? 'Compacting...' : `${percentage}% context used`}
++        </span>
++        {tierLabel && (
++          <span style={{ opacity: 0.7 }}>
++            Last: {tierLabel}
++          </span>
++        )}
++      </div>
++    </div>
++  );
++}
++
++function getColor(ratio: number): string {
++  if (ratio < 0.5) return '#22c55e';  // green
++  if (ratio < 0.7) return '#eab308';  // yellow
++  if (ratio < 0.85) return '#f97316'; // orange
++  return '#ef4444';                    // red
++}
+diff --git a/packages/react/src/index.ts b/packages/react/src/index.ts
+index 1234567..abcdef0 100644
+--- a/packages/react/src/index.ts
++++ b/packages/react/src/index.ts
+@@ -1,3 +1,5 @@
+ // NOTE: This patch adds new exports. Merge with existing index.ts exports.
+ // Add these lines to the existing barrel export file:
++export { useContextHealth } from './hooks/useContextHealth';
++export { ContextIndicator } from './components/ContextIndicator';
+ // End of context management additions
+diff --git a/packages/core/src/index.ts b/packages/core/src/index.ts
+index 1234567..abcdef0 100644
+--- a/packages/core/src/index.ts
++++ b/packages/core/src/index.ts
+@@ -1,3 +1,3 @@
+ // NOTE: This patch adds new type exports. Merge with existing index.ts exports.
+ // Add these to the existing barrel export file:
+-// (existing exports)
++export type { CompactionTier, ContextCompactionEvent, ContextHealth } from './types';

--- a/server/distri-core/src/agent/context.rs
+++ b/server/distri-core/src/agent/context.rs
@@ -977,6 +977,95 @@ impl ExecutorContext {
         *guard = id;
     }
 
+    /// Evaluate context size and perform compaction if needed.
+    ///
+    /// This should be called before each LLM call in the agent loop.
+    /// It checks the current context usage ratio against configured thresholds
+    /// and applies the appropriate compaction tier:
+    /// - Tier 1 (Trim): Mechanical truncation of old entries
+    /// - Tier 2 (Summarize): Signals that LLM summarization is needed
+    /// - Tier 3 (Reset): Emergency - keeps only task + last 2 entries
+    ///
+    /// Emits a `ContextCompaction` event when compaction occurs.
+    /// Returns the compaction result for the caller to act on (e.g., perform LLM summarization).
+    pub async fn evaluate_compaction(
+        &self,
+    ) -> Result<
+        Option<crate::agent::context_size_manager::CompactionResult>,
+        AgentError,
+    > {
+        let orchestrator = self.orchestrator.as_ref().ok_or(AgentError::Execution(
+            "Orchestrator not initialized".to_string(),
+        ))?;
+
+        let scratchpad_store = orchestrator.stores.scratchpad_store.clone();
+        let entries = scratchpad_store
+            .get_entries(&self.thread_id, &self.task_id, None)
+            .await
+            .unwrap_or_default();
+
+        if entries.is_empty() {
+            return Ok(None);
+        }
+
+        let max_tokens = self.get_scratchpad_token_limit();
+        let manager =
+            crate::agent::context_size_manager::ContextSizeManager::with_max_tokens(max_tokens);
+        let result = manager.evaluate_and_compact(&entries);
+
+        // If compaction was applied, emit the event
+        if let Some(ref tier) = result.tier {
+            self.emit(AgentEventType::ContextCompaction {
+                tier: tier.clone(),
+                tokens_before: result.tokens_before,
+                tokens_after: result.tokens_after,
+                entries_affected: result.entries_affected,
+                context_limit: max_tokens,
+                usage_ratio: result.usage_ratio,
+                summary: None,
+            })
+            .await;
+
+            tracing::info!(
+                "Context compaction ({:?}): {} → {} tokens, {} entries affected, {:.0}% usage",
+                tier,
+                result.tokens_before,
+                result.tokens_after,
+                result.entries_affected,
+                result.usage_ratio * 100.0,
+            );
+
+            return Ok(Some(result));
+        }
+
+        Ok(None)
+    }
+
+    /// Store a compaction summary in the scratchpad.
+    /// Called after Tier 2 LLM summarization produces a summary text.
+    pub async fn store_compaction_summary(
+        &self,
+        summary: distri_types::CompactionSummary,
+    ) -> Result<(), AgentError> {
+        let orchestrator = self.orchestrator.as_ref().ok_or(AgentError::Execution(
+            "Orchestrator not initialized".to_string(),
+        ))?;
+
+        let entry = ScratchpadEntry {
+            timestamp: chrono::Utc::now().timestamp_millis(),
+            entry_type: ScratchpadEntryType::Summary(summary),
+            task_id: self.task_id.clone(),
+            parent_task_id: self.parent_task_id.clone(),
+            entry_kind: Some("summary".to_string()),
+        };
+
+        let scratchpad_store = orchestrator.stores.scratchpad_store.clone();
+        scratchpad_store
+            .add_entry(&self.thread_id, entry)
+            .await?;
+        Ok(())
+    }
+
     /// Set agent_id - for context switching in multi-agent scenarios
     pub async fn set_agent_id(&mut self, agent_id: String) {
         self.agent_id = agent_id;

--- a/server/distri-core/src/agent/context_size_manager.rs
+++ b/server/distri-core/src/agent/context_size_manager.rs
@@ -1,4 +1,5 @@
 use crate::agent::token_estimator::{EstimationMethod, TokenEstimator};
+use distri_types::events::CompactionTier;
 use distri_types::{ScratchpadEntry, ScratchpadEntryType};
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +14,14 @@ pub struct ContextSizeConfig {
     pub min_entries: usize,
     /// Whether to preserve the user task entry at the top
     pub preserve_user_task: bool,
+    /// Usage ratio threshold to trigger Tier 1 (mechanical) compaction (default: 0.6)
+    pub trim_threshold: f64,
+    /// Usage ratio threshold to trigger Tier 2 (semantic) compaction (default: 0.8)
+    pub summarize_threshold: f64,
+    /// Usage ratio threshold to trigger Tier 3 (emergency reset) (default: 0.95)
+    pub reset_threshold: f64,
+    /// Target usage ratio after compaction (default: 0.4)
+    pub post_compaction_target: f64,
 }
 
 impl Default for ContextSizeConfig {
@@ -22,8 +31,29 @@ impl Default for ContextSizeConfig {
             estimation_method: EstimationMethod::Max,
             min_entries: 3, // User task + at least 2 entries for context
             preserve_user_task: true,
+            trim_threshold: 0.6,
+            summarize_threshold: 0.8,
+            reset_threshold: 0.95,
+            post_compaction_target: 0.4,
         }
     }
+}
+
+/// Result of a compaction evaluation
+#[derive(Debug, Clone)]
+pub struct CompactionResult {
+    /// Which tier was applied, if any
+    pub tier: Option<CompactionTier>,
+    /// Token count before compaction
+    pub tokens_before: usize,
+    /// Token count after compaction
+    pub tokens_after: usize,
+    /// Number of entries affected
+    pub entries_affected: usize,
+    /// The compacted entries
+    pub entries: Vec<ScratchpadEntry>,
+    /// Usage ratio that triggered compaction
+    pub usage_ratio: f64,
 }
 
 /// Manages context size by trimming scratchpad entries based on token count
@@ -276,6 +306,107 @@ impl ContextSizeManager {
         }
 
         total_tokens
+    }
+
+    /// Evaluate whether compaction is needed and apply the appropriate tier.
+    ///
+    /// Returns a `CompactionResult` describing what happened:
+    /// - `tier: None` means no compaction was needed
+    /// - `tier: Some(Trim)` means mechanical compaction was applied
+    /// - `tier: Some(Summarize)` means semantic compaction is recommended
+    ///   (caller must perform LLM summarization and replace entries)
+    /// - `tier: Some(Reset)` means emergency — only essentials preserved
+    pub fn evaluate_and_compact(&self, entries: &[ScratchpadEntry]) -> CompactionResult {
+        let tokens_before = self.estimate_scratchpad_tokens(entries);
+        let usage_ratio = if self.config.max_tokens > 0 {
+            tokens_before as f64 / self.config.max_tokens as f64
+        } else {
+            0.0
+        };
+
+        // No compaction needed
+        if usage_ratio < self.config.trim_threshold {
+            return CompactionResult {
+                tier: None,
+                tokens_before,
+                tokens_after: tokens_before,
+                entries_affected: 0,
+                entries: entries.to_vec(),
+                usage_ratio,
+            };
+        }
+
+        // Tier 3: Emergency reset — keep only task + last 2 entries
+        if usage_ratio >= self.config.reset_threshold {
+            let trimmed = self.emergency_reset(entries);
+            let tokens_after = self.estimate_scratchpad_tokens(&trimmed);
+            let entries_affected = entries.len().saturating_sub(trimmed.len());
+            return CompactionResult {
+                tier: Some(CompactionTier::Reset),
+                tokens_before,
+                tokens_after,
+                entries_affected,
+                entries: trimmed,
+                usage_ratio,
+            };
+        }
+
+        // Tier 2: Semantic compaction recommended (>= summarize_threshold)
+        // We return the mechanically trimmed entries but signal that LLM summarization
+        // should be performed by the caller.
+        if usage_ratio >= self.config.summarize_threshold {
+            let trimmed = self.trim_scratchpad_entries(entries);
+            let tokens_after = self.estimate_scratchpad_tokens(&trimmed);
+            let entries_affected = entries.len().saturating_sub(trimmed.len());
+            return CompactionResult {
+                tier: Some(CompactionTier::Summarize),
+                tokens_before,
+                tokens_after,
+                entries_affected,
+                entries: trimmed,
+                usage_ratio,
+            };
+        }
+
+        // Tier 1: Mechanical trim
+        let trimmed = self.trim_scratchpad_entries(entries);
+        let tokens_after = self.estimate_scratchpad_tokens(&trimmed);
+        let entries_affected = entries.len().saturating_sub(trimmed.len());
+        CompactionResult {
+            tier: Some(CompactionTier::Trim),
+            tokens_before,
+            tokens_after,
+            entries_affected,
+            entries: trimmed,
+            usage_ratio,
+        }
+    }
+
+    /// Emergency reset: keep only user task + last 2 non-task entries
+    fn emergency_reset(&self, entries: &[ScratchpadEntry]) -> Vec<ScratchpadEntry> {
+        let mut result = Vec::new();
+
+        // Preserve user task
+        if self.config.preserve_user_task {
+            if let Some(task) = entries
+                .iter()
+                .find(|e| matches!(e.entry_type, ScratchpadEntryType::Task(_)))
+            {
+                result.push(task.clone());
+            }
+        }
+
+        // Keep last 2 non-task entries
+        let non_task: Vec<_> = entries
+            .iter()
+            .filter(|e| !matches!(e.entry_type, ScratchpadEntryType::Task(_)))
+            .collect();
+        let keep_count = std::cmp::min(2, non_task.len());
+        for entry in non_task.iter().rev().take(keep_count).rev() {
+            result.push((*entry).clone());
+        }
+
+        result
     }
 
     /// Get current configuration

--- a/server/distri-core/src/agent/strategy/planning/formatter.rs
+++ b/server/distri-core/src/agent/strategy/planning/formatter.rs
@@ -359,6 +359,17 @@ impl<'a> MessageFormatter<'a> {
                     Self::execution_result_to_messages(&exec_entry.execution_result, use_compaction)
                 }
                 ScratchpadEntryType::Task(_) => Vec::new(),
+                ScratchpadEntryType::Summary(summary) => {
+                    // Render compaction summaries as system-like context messages
+                    let mut msg = crate::types::Message::default();
+                    msg.role = MessageRole::Assistant;
+                    msg.created_at = entry.1.timestamp;
+                    msg.parts = vec![Part::Text(format!(
+                        "[Context summary — {} earlier entries compacted]: {}",
+                        summary.entries_summarized, summary.summary_text
+                    ))];
+                    vec![msg]
+                }
             })
             .collect()
     }

--- a/server/distri-core/src/agent/strategy/planning/scratchpad.rs
+++ b/server/distri-core/src/agent/strategy/planning/scratchpad.rs
@@ -21,8 +21,10 @@ pub fn format_scratchpad_with_task_filter(
                     ScratchpadEntryType::Execution(exec_entry) => {
                         exec_entry.task_id == filter_task_id
                     }
-                    // Include plan steps and tasks for all agents for context
-                    ScratchpadEntryType::PlanStep(_) | ScratchpadEntryType::Task(_) => true,
+                    // Include plan steps, tasks, and summaries for all agents for context
+                    ScratchpadEntryType::PlanStep(_)
+                    | ScratchpadEntryType::Task(_)
+                    | ScratchpadEntryType::Summary(_) => true,
                 }
             })
             .collect()
@@ -106,6 +108,12 @@ pub fn format_scratchpad_with_task_filter(
                 scratchpad.push_str(&format!(
                     "Observation: {}\n",
                     observation_result.as_observation()
+                ));
+            }
+            ScratchpadEntryType::Summary(summary) => {
+                scratchpad.push_str(&format!(
+                    "Summary (compacted {} entries): {}\n",
+                    summary.entries_summarized, summary.summary_text
                 ));
             }
         }

--- a/server/distri-server-cli/src/run/printer.rs
+++ b/server/distri-server-cli/src/run/printer.rs
@@ -858,6 +858,32 @@ impl EventPrinter {
             AgentEventType::BrowserSessionStarted { .. } => {
                 // Browser Session Started
             }
+            AgentEventType::ContextCompaction {
+                tier,
+                tokens_before,
+                tokens_after,
+                entries_affected,
+                usage_ratio,
+                summary,
+                ..
+            } => {
+                self.ensure_newline();
+                let tier_label = match tier {
+                    distri_types::events::CompactionTier::Trim => "trim",
+                    distri_types::events::CompactionTier::Summarize => "summarize",
+                    distri_types::events::CompactionTier::Reset => "reset",
+                };
+                eprintln!(
+                    "  {COLOR_YELLOW}Context compacted ({tier_label}): {tokens_before} → {tokens_after} tokens ({entries_affected} entries, {:.0}% usage){COLOR_RESET}",
+                    usage_ratio * 100.0,
+                );
+                if let Some(summary_text) = summary {
+                    let preview: String = summary_text.chars().take(120).collect();
+                    eprintln!(
+                        "  {COLOR_GRAY}Summary: {preview}...{COLOR_RESET}",
+                    );
+                }
+            }
         };
 
         Ok(())

--- a/server/notes/context-management-design.md
+++ b/server/notes/context-management-design.md
@@ -1,0 +1,255 @@
+# Context Management & Compaction Design
+
+## Problem Statement
+
+As agent conversations grow, context windows fill up. This causes:
+1. **Token budget exhaustion** - LLM calls fail or get expensive
+2. **Quality degradation** - Models lose focus with too much irrelevant context
+3. **Latency increase** - Larger prompts = slower responses
+
+Both OpenAI Codex and Claude Code solve this by running a **compaction step** when context approaches limits, summarizing older conversation history while preserving recent and critical information.
+
+## Current State (distri)
+
+Distri already has foundational pieces:
+
+- **`ContextSizeManager`** (`context_size_manager.rs`): Token estimation and FIFO trimming of scratchpad entries
+- **`compact_for_history()`** (`execution.rs`): Per-entry payload truncation (text to 2K chars, JSON to 4K, images stripped)
+- **Scratchpad trimming**: Oldest entries dropped, user task preserved, latest execution kept full
+- **`ContextUsage` tracking**: Token counts maintained per-run
+
+### What's Missing
+
+1. **No LLM-powered summarization** - Current compaction is mechanical truncation, not semantic compression
+2. **No compaction event** - Clients/CLI have no visibility into when/why compaction happens
+3. **No tiered compaction strategy** - No distinction between "trim", "summarize", and "reset"
+4. **No client-side awareness** - distrijs/@distri/react can't respond to compaction events
+
+## Design: Tiered Context Compaction
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Context Budget Monitor                     │
+│  Runs before each LLM call in the agent loop                │
+│  Checks: estimated_tokens / context_limit                   │
+└─────────────────┬───────────────────────────────────────────┘
+                  │
+          ┌───────┴────────┐
+          │ Usage Ratio?   │
+          └───────┬────────┘
+                  │
+    ┌─────────────┼─────────────────┐
+    ▼             ▼                 ▼
+ < 60%        60-80%            > 80%
+ (No-op)   (Tier 1: Trim)   (Tier 2: Summarize)
+              │                   │
+              ▼                   ▼
+    Drop old entries      LLM summarization
+    Compact payloads      of conversation so far
+    Keep last N full      Replace history with
+                          summary + recent entries
+```
+
+### Tier 1: Mechanical Compaction (60-80% usage)
+
+This is what we largely have today, enhanced with the event system:
+
+1. Apply `compact_for_history()` to all entries except the latest
+2. Drop entries beyond `min_entries` threshold
+3. Emit `ContextCompaction` event with stats
+
+### Tier 2: Semantic Compaction (>80% usage)
+
+Inspired by Claude Code's auto-compress and Codex's context condensing:
+
+1. Collect all scratchpad entries + message history
+2. Send to LLM with a summarization prompt:
+   - "Summarize the conversation so far, preserving: key decisions, current task state, tool results that matter"
+3. Replace old history with a single `ScratchpadEntryType::Summary` entry
+4. Keep the last N (configurable) entries full-fidelity
+5. Emit `ContextCompaction` event with `tier: Summarize`
+
+### Tier 3: Context Reset (>95% usage, emergency)
+
+When even summarization can't fit:
+
+1. Preserve only: user task, latest summary, last 2 entries
+2. Emit `ContextCompaction` event with `tier: Reset`
+3. Log warning for observability
+
+## New Event: `ContextCompaction`
+
+```rust
+/// Emitted when the agent performs context compaction
+ContextCompaction {
+    /// Which tier of compaction was applied
+    tier: CompactionTier,
+    /// Token count before compaction
+    tokens_before: usize,
+    /// Token count after compaction
+    tokens_after: usize,
+    /// Number of entries removed or summarized
+    entries_affected: usize,
+    /// Context budget limit that triggered compaction
+    context_limit: usize,
+    /// Usage ratio that triggered compaction (0.0 - 1.0)
+    usage_ratio: f64,
+    /// Optional summary text (for Tier 2)
+    summary: Option<String>,
+}
+```
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionTier {
+    /// Mechanical: drop old entries, truncate payloads
+    Trim,
+    /// Semantic: LLM-powered summarization of history
+    Summarize,
+    /// Emergency: preserve only essentials
+    Reset,
+}
+```
+
+## New Scratchpad Entry Type: `Summary`
+
+```rust
+pub enum ScratchpadEntryType {
+    Task(Vec<Part>),
+    PlanStep(PlanStep),
+    Execution(ExecutionHistoryEntry),
+    /// Compressed summary of older entries, produced by Tier 2 compaction
+    Summary(CompactionSummary),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompactionSummary {
+    /// LLM-generated summary of compacted history
+    pub summary_text: String,
+    /// Number of entries that were summarized
+    pub entries_summarized: usize,
+    /// Timestamp range of summarized entries
+    pub from_timestamp: i64,
+    pub to_timestamp: i64,
+    /// Token count saved by this compaction
+    pub tokens_saved: usize,
+}
+```
+
+## Integration Points
+
+### 1. Agent Loop (`strategy/planning/`)
+
+Before each LLM call:
+
+```
+1. Estimate current context tokens
+2. Check ratio against context_limit
+3. If > threshold, run appropriate compaction tier
+4. Emit ContextCompaction event
+5. Proceed with LLM call using compacted context
+```
+
+### 2. CLI (`distri-server-cli/run/printer.rs`)
+
+Handle `ContextCompaction` event:
+
+```
+🗜️ Context compacted (trim): 12,400 → 6,200 tokens (8 entries affected)
+```
+
+or for summarization:
+
+```
+🗜️ Context compacted (summarize): 45,000 → 8,000 tokens
+   Summary: "User is building a REST API for task management..."
+```
+
+### 3. distrijs / @distri/react
+
+New event in the streaming protocol:
+
+```typescript
+interface ContextCompactionEvent {
+  type: 'context_compaction';
+  tier: 'trim' | 'summarize' | 'reset';
+  tokens_before: number;
+  tokens_after: number;
+  entries_affected: number;
+  usage_ratio: number;
+  summary?: string;
+}
+```
+
+React hook for responding to compaction:
+
+```typescript
+// In useChatMessages or a new useContextHealth hook
+const { contextHealth, lastCompaction } = useContextHealth();
+// contextHealth: { usage_ratio, tokens_used, tokens_limit, last_compaction }
+```
+
+View component:
+
+```tsx
+function ContextIndicator() {
+  const { contextHealth } = useContextHealth();
+  if (!contextHealth) return null;
+
+  return (
+    <div className="context-indicator">
+      <ProgressBar value={contextHealth.usage_ratio} />
+      {contextHealth.last_compaction && (
+        <span>Context compacted: {contextHealth.last_compaction.tier}</span>
+      )}
+    </div>
+  );
+}
+```
+
+### 4. `ContextSizeConfig` Updates
+
+```rust
+pub struct ContextSizeConfig {
+    pub max_tokens: usize,
+    pub estimation_method: EstimationMethod,
+    pub min_entries: usize,
+    pub preserve_user_task: bool,
+    // NEW
+    pub trim_threshold: f64,       // Default: 0.6
+    pub summarize_threshold: f64,  // Default: 0.8
+    pub reset_threshold: f64,      // Default: 0.95
+    pub summary_model: Option<String>, // Model to use for summarization
+    pub post_compaction_target: f64,   // Target usage after compaction (default: 0.4)
+}
+```
+
+## Comparison with Existing Approaches
+
+### Claude Code
+- Compresses prior messages when approaching context limits
+- Uses "auto-compact" that produces a summary
+- Summary preserved across message turns
+- **Distri parallel**: Our Tier 2 summarization follows this pattern
+
+### OpenAI Codex
+- "Context condensing" when context window fills
+- Keeps working state (files being edited, test results)
+- Discards intermediate reasoning
+- **Distri parallel**: Our Tier 1 trim + compact_for_history handles this
+
+### Common Agent Frameworks (LangChain, CrewAI)
+- Buffer memory with max token windows
+- Summary memory that runs periodic summarization
+- Conversation buffer window (sliding window)
+- **Distri parallel**: Our tiered approach combines all three strategies
+
+## Implementation Priority
+
+1. **Phase 1** (this PR): Add `ContextCompaction` event + `CompactionTier` enum + CLI rendering
+2. **Phase 2**: Wire compaction trigger into agent loop before LLM calls
+3. **Phase 3**: Implement Tier 2 LLM summarization with `Summary` scratchpad entry
+4. **Phase 4**: distrijs patch for React/client-side awareness


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive context management system with tiered compaction strategies to handle token budget constraints in long-running agent conversations. It adds event emission, configuration thresholds, and the foundational infrastructure for both mechanical and semantic (LLM-powered) context compression.

## Key Changes

### Core Infrastructure
- **New `CompactionTier` enum** (`distri-types/events.rs`): Defines three compaction levels:
  - `Trim`: Mechanical truncation of old entries and payload compaction
  - `Summarize`: LLM-powered semantic compression (recommended at >80% usage)
  - `Reset`: Emergency mode preserving only essentials (>95% usage)

- **New `ContextCompaction` event** (`distri-types/events.rs`): Emitted when compaction occurs, includes:
  - Tier applied, token counts before/after, entries affected
  - Usage ratio and context limit for client awareness
  - Optional summary text for Tier 2 summarization

- **New `CompactionSummary` scratchpad entry type** (`distri-types/execution.rs`): Stores LLM-generated summaries of compacted history with metadata (entries summarized, timestamp range, tokens saved)

### Context Size Manager Enhancements
- **New configuration thresholds** (`context_size_manager.rs`):
  - `trim_threshold` (default 0.6): Trigger mechanical compaction
  - `summarize_threshold` (default 0.8): Trigger semantic compaction
  - `reset_threshold` (default 0.95): Trigger emergency reset
  - `post_compaction_target` (default 0.4): Target usage after compaction

- **`CompactionResult` struct**: Encapsulates compaction evaluation results with tier, token counts, affected entries, and usage ratio

- **`evaluate_and_compact()` method**: Evaluates current context usage and applies appropriate tier without modifying entries (caller responsible for LLM summarization)

- **`emergency_reset()` method**: Preserves only user task + last 2 entries for extreme cases

### Executor Context Integration
- **`evaluate_compaction()` method** (`context.rs`): Evaluates context and emits `ContextCompaction` event; should be called before each LLM call in agent loop

- **`store_compaction_summary()` method** (`context.rs`): Stores LLM-generated summaries in scratchpad after Tier 2 compaction

### CLI Support
- **Event rendering** (`distri-server-cli/printer.rs`): Displays compaction events with tier label, token savings, entry count, and usage percentage; includes summary preview for Tier 2

### Scratchpad Formatting
- **Summary entry rendering** (`formatter.rs`): Compaction summaries formatted as assistant messages in context
- **Summary entry filtering** (`scratchpad.rs`): Summaries included in scratchpad context alongside tasks and plan steps

### Client-Side Types (distrijs)
- **TypeScript types** (`distrijs-context-management.patch`):
  - `CompactionTier`, `ContextCompactionEvent`, `ContextHealth` types
  - `useContextHealth()` hook for tracking context usage and compaction events
  - `ContextIndicator` React component for visual context health display with color-coded progress bar

## Implementation Notes

- **Tier 2 (Summarize) is signaled but not auto-executed**: The `evaluate_and_compact()` method returns a result indicating summarization is needed, but the actual LLM call is left to the caller (agent loop) to implement
- **Mechanical compaction (Tier 1) is applied immediately**: Truncation and entry dropping happen in `evaluate_and_compact()`
- **Event emission happens in executor context**: Allows clients to track compaction across the event stream
- **Backward compatible**: New scratchpad entry type and event are additive; existing code paths unaffected
- **Design mirrors production systems**: Follows patterns from Claude Code (auto-compress) and OpenAI Codex (context condensing)

## Testing Considerations

- Verify compaction thresholds trigger at correct usage ratios
- Confirm

https://claude.ai/code/session_01BG3BRtrAJf7C7uE11X8TXK