### PR TITLE
feat: multi-entry point workflows with skip_if

### DIFF
--- a/distri-cli/src/commands.rs
+++ b/distri-cli/src/commands.rs
@@ -645,6 +645,11 @@ pub async fn handle_workflow_command(client: &distri::Distri, command: WorkflowC
                                 status, steps_done, steps_failed
                             );
                         }
+                        WorkflowEvent::StepWaiting {
+                            step_id, message, ..
+                        } => {
+                            println!(" ✋ {} — waiting for input: {}", step_id, message);
+                        }
                     }
                 }
                 let _ = handle.await;

--- a/distri-home/src/components/WorkflowEntryPointSelector.tsx
+++ b/distri-home/src/components/WorkflowEntryPointSelector.tsx
@@ -1,0 +1,259 @@
+import { useState, useMemo, type ReactNode } from 'react';
+import type { WorkflowDefinition, EntryPoint, WorkflowStep, StepStatus } from '@distri/core';
+import { workflowProgress, countSteps, applyEntryPoint } from '@distri/core';
+import {
+  ChevronRight,
+  Play,
+  SkipForward,
+  Circle,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Ban,
+  FastForward,
+  Info,
+} from 'lucide-react';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface WorkflowEntryPointSelectorProps {
+  /** The workflow definition with entry_points defined */
+  workflow: WorkflowDefinition;
+  /** Called when the user selects an entry point and clicks "Start" */
+  onStart: (entryPointId: string | null, workflow: WorkflowDefinition) => void;
+  /** Whether a workflow is currently running */
+  isRunning?: boolean;
+  /** Optional class name */
+  className?: string;
+}
+
+// ── Step status icon ──────────────────────────────────────────────────────
+
+function StepStatusIcon({ status }: { status: StepStatus }) {
+  switch (status) {
+    case 'done': return <CheckCircle2 className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-green-500" />;
+    case 'failed': return <XCircle className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-red-500" />;
+    case 'running': return <Clock className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-blue-500 animate-spin" />;
+    case 'skipped': return <FastForward className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />;
+    case 'blocked': return <Ban className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-orange-500" />;
+    case 'pending': return <Circle className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />;
+  }
+}
+
+// ── Entry point card ──────────────────────────────────────────────────────
+
+function EntryPointCard({
+  entryPoint,
+  workflow,
+  selected,
+  onSelect,
+}: {
+  entryPoint: EntryPoint | null; // null = "from beginning"
+  workflow: WorkflowDefinition;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const preview = useMemo(() => {
+    if (!entryPoint) return workflow;
+    try {
+      return applyEntryPoint(workflow, entryPoint.id);
+    } catch {
+      return workflow;
+    }
+  }, [entryPoint, workflow]);
+
+  const counts = useMemo(() => countSteps(preview), [preview]);
+  const stepsToRun = preview.steps.filter(s => s.status !== 'skipped').length;
+  const stepsSkipped = counts.skipped;
+
+  return (
+    <button
+      onClick={onSelect}
+      className={`
+        w-full text-left p-3 sm:p-4 rounded-lg border transition-colors
+        ${selected
+          ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
+          : 'border-border hover:border-muted-foreground/30 hover:bg-muted/50'
+        }
+      `}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <h4 className="text-sm sm:text-base font-medium text-foreground truncate">
+            {entryPoint?.label ?? 'Start from beginning'}
+          </h4>
+          {entryPoint?.description && (
+            <p className="text-xs sm:text-sm text-muted-foreground mt-0.5 line-clamp-2">
+              {entryPoint.description}
+            </p>
+          )}
+          <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Play className="h-3 w-3" />
+              {stepsToRun} step{stepsToRun !== 1 ? 's' : ''}
+            </span>
+            {stepsSkipped > 0 && (
+              <span className="flex items-center gap-1">
+                <SkipForward className="h-3 w-3" />
+                {stepsSkipped} skipped
+              </span>
+            )}
+            {entryPoint?.starts_at && (
+              <span className="flex items-center gap-1">
+                <ChevronRight className="h-3 w-3" />
+                starts at <code className="bg-muted px-1 rounded text-[10px]">{entryPoint.starts_at}</code>
+              </span>
+            )}
+          </div>
+        </div>
+        <div className={`
+          h-4 w-4 rounded-full border-2 flex-shrink-0 mt-0.5 transition-colors
+          ${selected ? 'border-primary bg-primary' : 'border-muted-foreground/30'}
+        `}>
+          {selected && (
+            <svg className="h-full w-full text-primary-foreground" viewBox="0 0 16 16">
+              <circle cx="8" cy="8" r="3" fill="currentColor" />
+            </svg>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ── Step preview ──────────────────────────────────────────────────────────
+
+function StepPreview({ steps }: { steps: WorkflowStep[] }) {
+  return (
+    <div className="space-y-1">
+      {steps.map((step) => (
+        <div
+          key={step.id}
+          className={`
+            flex items-center gap-2 py-1.5 px-2 rounded text-xs sm:text-sm
+            ${step.status === 'skipped' ? 'opacity-40' : ''}
+          `}
+        >
+          <StepStatusIcon status={step.status ?? 'pending'} />
+          <span className="truncate flex-1">{step.label}</span>
+          <span className="text-[10px] text-muted-foreground font-mono">{step.id}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────
+
+export function WorkflowEntryPointSelector({
+  workflow,
+  onStart,
+  isRunning = false,
+  className = '',
+}: WorkflowEntryPointSelectorProps) {
+  const entryPoints = workflow.entry_points ?? [];
+  const hasEntryPoints = entryPoints.length > 0;
+
+  // null = "from beginning"
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const selectedPreview = useMemo(() => {
+    if (!selectedId) return workflow;
+    try {
+      return applyEntryPoint(workflow, selectedId);
+    } catch {
+      return workflow;
+    }
+  }, [selectedId, workflow]);
+
+  const handleStart = () => {
+    onStart(selectedId, selectedPreview);
+  };
+
+  if (!hasEntryPoints) {
+    // No entry points — just show a simple start button
+    return (
+      <div className={`space-y-3 ${className}`}>
+        <StepPreview steps={workflow.steps} />
+        <button
+          onClick={() => onStart(null, workflow)}
+          disabled={isRunning}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isRunning ? (
+            <Clock className="h-4 w-4 animate-spin" />
+          ) : (
+            <Play className="h-4 w-4" />
+          )}
+          {isRunning ? 'Running...' : 'Start Workflow'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      {/* Entry point selector */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-2">Choose entry point</h3>
+        <div className="space-y-2">
+          {/* Default: from beginning */}
+          <EntryPointCard
+            entryPoint={null}
+            workflow={workflow}
+            selected={selectedId === null}
+            onSelect={() => setSelectedId(null)}
+          />
+          {/* Named entry points */}
+          {entryPoints.map((ep) => (
+            <EntryPointCard
+              key={ep.id}
+              entryPoint={ep}
+              workflow={workflow}
+              selected={selectedId === ep.id}
+              onSelect={() => setSelectedId(ep.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Required inputs hint */}
+      {selectedId && (() => {
+        const ep = entryPoints.find(e => e.id === selectedId);
+        if (!ep?.required_inputs?.length) return null;
+        return (
+          <div className="flex items-start gap-2 p-2.5 bg-muted/50 rounded-lg text-xs text-muted-foreground">
+            <Info className="h-3.5 w-3.5 flex-shrink-0 mt-0.5" />
+            <span>
+              Required inputs: {ep.required_inputs.map(r => (
+                <code key={r} className="bg-muted px-1 rounded mx-0.5">{r}</code>
+              ))}
+            </span>
+          </div>
+        );
+      })()}
+
+      {/* Step preview */}
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-2">Steps</h3>
+        <div className="border rounded-lg p-2 bg-muted/20 max-h-60 overflow-y-auto">
+          <StepPreview steps={selectedPreview.steps} />
+        </div>
+      </div>
+
+      {/* Start button */}
+      <button
+        onClick={handleStart}
+        disabled={isRunning}
+        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-primary text-primary-foreground rounded-lg text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {isRunning ? (
+          <Clock className="h-4 w-4 animate-spin" />
+        ) : (
+          <Play className="h-4 w-4" />
+        )}
+        {isRunning ? 'Running...' : selectedId ? `Start from "${entryPoints.find(e => e.id === selectedId)?.label}"` : 'Start from beginning'}
+      </button>
+    </div>
+  );
+}

--- a/distri-home/src/components/WorkflowEntryPointSelector.tsx
+++ b/distri-home/src/components/WorkflowEntryPointSelector.tsx
@@ -36,6 +36,7 @@ function StepStatusIcon({ status }: { status: StepStatus }) {
     case 'running': return <Clock className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-blue-500 animate-spin" />;
     case 'skipped': return <FastForward className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />;
     case 'blocked': return <Ban className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-orange-500" />;
+    case 'waiting_for_input': return <Clock className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-amber-500" />;
     case 'pending': return <Circle className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-muted-foreground" />;
   }
 }

--- a/distri-home/src/index.ts
+++ b/distri-home/src/index.ts
@@ -24,6 +24,7 @@ export type { AgentSettingsViewProps } from './components/AgentSettingsView';
 export { PromptTemplatesView } from './components/PromptTemplatesView';
 export { SessionsView } from './components/SessionsView';
 export { CodePanel } from './components/CodePanel';
+export { WorkflowEntryPointSelector } from './components/WorkflowEntryPointSelector';
 export type { HomeProps } from './components/Home';
 export type { AgentDetailsProps } from './components/AgentDetails';
 export type { ThreadsViewProps } from './components/ThreadsView';
@@ -31,3 +32,4 @@ export type { SettingsViewProps, SettingsSection } from './components/SettingsVi
 export type { SecretsViewProps } from './components/SecretsView';
 export type { SessionsViewProps } from './components/SessionsView';
 export type { CodePanelProps, CodeLanguage } from './components/CodePanel';
+export type { WorkflowEntryPointSelectorProps } from './components/WorkflowEntryPointSelector';

--- a/distri-workflow/src/executor.rs
+++ b/distri-workflow/src/executor.rs
@@ -53,6 +53,14 @@ impl EventSink for TracingEventSink {
             } => {
                 tracing::info!(%workflow_id, ?status, steps_done, steps_failed, "workflow completed");
             }
+            WorkflowEvent::StepWaiting {
+                step_id,
+                step_label,
+                message,
+                ..
+            } => {
+                tracing::info!(%step_id, %step_label, %message, "step waiting for input");
+            }
         }
     }
 }
@@ -210,7 +218,36 @@ impl<S: WorkflowStateStore, E: StepExecutor, K: EventSink> WorkflowRunner<S, E, 
             return Ok(vec![]);
         }
 
-        let (parallel, sequential): (Vec<_>, Vec<_>) = executable
+        // Filter out WaitForInput steps from parallel — they always pause
+        let (wait_steps, non_wait): (Vec<_>, Vec<_>) = executable
+            .into_iter()
+            .partition(|(_, _, _, step)| matches!(step.kind, StepKind::WaitForInput { .. }));
+
+        // If any WaitForInput step is runnable, pause on the first one
+        if !wait_steps.is_empty() {
+            let (idx, step_id, _, step) = &wait_steps[0];
+            let (message, schema) = match &step.kind {
+                StepKind::WaitForInput { message, schema } => (message.clone(), schema.clone()),
+                _ => unreachable!(),
+            };
+            workflow.steps[*idx].status = StepStatus::WaitingForInput;
+            workflow.steps[*idx].started_at = Some(chrono::Utc::now());
+            workflow.status = WorkflowStatus::Paused;
+            workflow.current_step = *idx;
+            self.store.save(&workflow).await?;
+            self.events
+                .emit(WorkflowEvent::StepWaiting {
+                    workflow_id: workflow_id.to_string(),
+                    step_id: step_id.clone(),
+                    step_label: step.label.clone(),
+                    message,
+                    schema,
+                })
+                .await;
+            return Ok(vec![]);
+        }
+
+        let (parallel, sequential): (Vec<_>, Vec<_>) = non_wait
             .into_iter()
             .partition(|(_, _, exec, _)| *exec == StepExecution::Parallel);
 
@@ -361,10 +398,7 @@ impl<S: WorkflowStateStore, E: StepExecutor, K: EventSink> WorkflowRunner<S, E, 
                 .ok_or("Workflow not found")?;
 
             match workflow.status {
-                WorkflowStatus::Completed
-                | WorkflowStatus::Failed
-                | WorkflowStatus::Paused
-                | WorkflowStatus::Blocked => {
+                WorkflowStatus::Completed | WorkflowStatus::Failed | WorkflowStatus::Blocked => {
                     let done = workflow
                         .steps
                         .iter()
@@ -384,6 +418,10 @@ impl<S: WorkflowStateStore, E: StepExecutor, K: EventSink> WorkflowRunner<S, E, 
                         })
                         .await;
                     return Ok(workflow.status);
+                }
+                // Paused = waiting for human input. Return without emitting completed.
+                WorkflowStatus::Paused => {
+                    return Ok(WorkflowStatus::Paused);
                 }
                 _ => {}
             }
@@ -432,6 +470,34 @@ impl<S: WorkflowStateStore, E: StepExecutor, K: EventSink> WorkflowRunner<S, E, 
                 return Ok(w.status);
             }
         }
+    }
+
+    /// Resume a paused workflow by providing input for the waiting step.
+    /// After providing the input, continues running all remaining steps.
+    pub async fn resume(
+        &self,
+        workflow_id: &str,
+        step_id: &str,
+        input: serde_json::Value,
+    ) -> Result<WorkflowStatus, String> {
+        let mut workflow = self
+            .store
+            .load(workflow_id)
+            .await?
+            .ok_or("Workflow not found")?;
+
+        if workflow.status != WorkflowStatus::Paused {
+            return Err(format!(
+                "Workflow is not paused (status: {:?})",
+                workflow.status
+            ));
+        }
+
+        workflow.resume_step(step_id, input)?;
+        self.store.save(&workflow).await?;
+
+        // Continue running remaining steps
+        self.run_all(workflow_id).await
     }
 
     /// Get current workflow state.

--- a/distri-workflow/src/executor.rs
+++ b/distri-workflow/src/executor.rs
@@ -141,6 +141,25 @@ impl<S: WorkflowStateStore, E: StepExecutor, K: EventSink> WorkflowRunner<S, E, 
             return Err("Workflow has failed steps".into());
         }
 
+        // Evaluate skip_if conditions on pending steps
+        let mut skipped_any = false;
+        for i in 0..workflow.steps.len() {
+            if workflow.steps[i].status != StepStatus::Pending {
+                continue;
+            }
+            if let Some(ref skip_expr) = workflow.steps[i].skip_if {
+                if resolve::evaluate_skip_condition(skip_expr, &workflow.context) {
+                    workflow.steps[i].status = StepStatus::Skipped;
+                    workflow.steps[i].completed_at = Some(chrono::Utc::now());
+                    workflow.add_note(&workflow.steps[i].id.clone(), "Skipped by skip_if condition");
+                    skipped_any = true;
+                }
+            }
+        }
+        if skipped_any {
+            self.store.save(&workflow).await?;
+        }
+
         // Collect runnable step info
         let runnable: Vec<(usize, String, StepExecution, WorkflowStep)> = workflow
             .runnable_steps()

--- a/distri-workflow/src/lib.rs
+++ b/distri-workflow/src/lib.rs
@@ -39,7 +39,10 @@ pub mod store;
 pub mod types;
 
 pub use executor::{EventSink, NoopEventSink, StepExecutor, TracingEventSink, WorkflowRunner};
-pub use resolve::{build_execution_context, resolve_step_input, resolve_template, resolve_value};
+pub use resolve::{
+    build_execution_context, evaluate_skip_condition, resolve_step_input, resolve_template,
+    resolve_value,
+};
 pub use store::{InMemoryStore, WorkflowStateStore};
 pub use types::*;
 

--- a/distri-workflow/src/resolve.rs
+++ b/distri-workflow/src/resolve.rs
@@ -140,6 +140,77 @@ pub fn resolve_step_input(step_input: Option<&Value>, context: &Value) -> Value 
     }
 }
 
+/// Evaluate a skip_if expression against the workflow context.
+///
+/// Expression format:
+/// - `{input.field}` or `{steps.X.field}` — truthy if field exists and is not null/false/empty string/0
+/// - `!{input.field}` — truthy if field is absent or falsy
+/// - `{input.field} == "value"` — equality check
+pub fn evaluate_skip_condition(expression: &str, context: &Value) -> bool {
+    let expr = expression.trim();
+
+    // Negation: !{ref}
+    if let Some(inner) = expr.strip_prefix('!') {
+        return !evaluate_skip_condition(inner.trim(), context);
+    }
+
+    // Equality: {ref} == "value"
+    if let Some((lhs, rhs)) = expr.split_once("==") {
+        let lhs = lhs.trim();
+        let rhs = rhs.trim().trim_matches('"');
+        let resolved = resolve_single_ref(lhs, context);
+        return match resolved {
+            Some(Value::String(s)) => s == rhs,
+            Some(Value::Number(n)) => n.to_string() == rhs,
+            Some(Value::Bool(b)) => b.to_string() == rhs,
+            _ => false,
+        };
+    }
+
+    // Inequality: {ref} != "value"
+    if let Some((lhs, rhs)) = expr.split_once("!=") {
+        let lhs = lhs.trim();
+        let rhs = rhs.trim().trim_matches('"');
+        let resolved = resolve_single_ref(lhs, context);
+        return match resolved {
+            Some(Value::String(s)) => s != rhs,
+            Some(Value::Number(n)) => n.to_string() != rhs,
+            Some(Value::Bool(b)) => b.to_string() != rhs,
+            None => true,
+            _ => true,
+        };
+    }
+
+    // Simple truthy check: {ref}
+    let resolved = resolve_single_ref(expr, context);
+    is_truthy(&resolved)
+}
+
+/// Resolve a `{namespace.path}` reference, stripping the braces.
+fn resolve_single_ref(expr: &str, context: &Value) -> Option<Value> {
+    let trimmed = expr.trim();
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        let reference = &trimmed[1..trimmed.len() - 1];
+        resolve_reference(reference, context)
+    } else {
+        // Try as bare reference without braces
+        resolve_reference(trimmed, context)
+    }
+}
+
+/// Check if a JSON value is "truthy".
+fn is_truthy(value: &Option<Value>) -> bool {
+    match value {
+        None => false,
+        Some(Value::Null) => false,
+        Some(Value::Bool(b)) => *b,
+        Some(Value::String(s)) => !s.is_empty(),
+        Some(Value::Number(n)) => n.as_f64().map_or(false, |f| f != 0.0),
+        Some(Value::Array(a)) => !a.is_empty(),
+        Some(Value::Object(o)) => !o.is_empty(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,6 +373,46 @@ mod tests {
             resolve_template("{input.nonexistent}", &ctx),
             "{input.nonexistent}"
         );
+    }
+
+    #[test]
+    fn evaluate_skip_truthy() {
+        let ctx = test_context();
+        assert!(super::evaluate_skip_condition("{input.doc_id}", &ctx));
+        assert!(!super::evaluate_skip_condition("{input.nonexistent}", &ctx));
+    }
+
+    #[test]
+    fn evaluate_skip_negation() {
+        let ctx = test_context();
+        assert!(!super::evaluate_skip_condition("!{input.doc_id}", &ctx));
+        assert!(super::evaluate_skip_condition("!{input.nonexistent}", &ctx));
+    }
+
+    #[test]
+    fn evaluate_skip_equality() {
+        let ctx = test_context();
+        assert!(super::evaluate_skip_condition("{input.doc_id} == \"abc123\"", &ctx));
+        assert!(!super::evaluate_skip_condition("{input.doc_id} == \"other\"", &ctx));
+    }
+
+    #[test]
+    fn evaluate_skip_inequality() {
+        let ctx = test_context();
+        assert!(super::evaluate_skip_condition("{input.doc_id} != \"other\"", &ctx));
+        assert!(!super::evaluate_skip_condition("{input.doc_id} != \"abc123\"", &ctx));
+    }
+
+    #[test]
+    fn evaluate_skip_array_truthy() {
+        let ctx = test_context();
+        assert!(super::evaluate_skip_condition("{input.tags}", &ctx));
+    }
+
+    #[test]
+    fn evaluate_skip_number_truthy() {
+        let ctx = test_context();
+        assert!(super::evaluate_skip_condition("{steps.fetch_doc.metadata.pages}", &ctx));
     }
 
     #[test]

--- a/distri-workflow/src/tests.rs
+++ b/distri-workflow/src/tests.rs
@@ -1574,4 +1574,240 @@ mod tests {
         let deserialized: WorkflowStep = serde_json::from_value(json).unwrap();
         assert_eq!(deserialized.skip_if.as_deref(), Some("{input.existing_id}"));
     }
+
+    // ========================================================================
+    // WaitForInput / Human-in-the-loop tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn wait_for_input_pauses_workflow() {
+        let steps = vec![
+            WorkflowStep::api_call("step1", "Step 1", "GET", "/api/data"),
+            WorkflowStep::wait_for_input("human_review", "Human Review", "Please review the data")
+                .with_depends_on(vec!["step1"]),
+            WorkflowStep::api_call("step3", "Step 3", "POST", "/api/submit")
+                .with_depends_on(vec!["human_review"]),
+        ];
+        let workflow = WorkflowDefinition::new(steps);
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+
+        // Run all — should execute step1 then pause at human_review
+        let status = runner.run_all(&workflow.id).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Paused);
+
+        let state = runner.get_state(&workflow.id).await.unwrap().unwrap();
+        assert_eq!(state.steps[0].status, StepStatus::Done);
+        assert_eq!(state.steps[1].status, StepStatus::WaitingForInput);
+        assert_eq!(state.steps[2].status, StepStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn resume_after_wait_completes_workflow() {
+        let steps = vec![
+            WorkflowStep::api_call("step1", "Step 1", "GET", "/api/data"),
+            WorkflowStep::wait_for_input("human_review", "Human Review", "Please review the data")
+                .with_depends_on(vec!["step1"]),
+            WorkflowStep::api_call("step3", "Step 3", "POST", "/api/submit")
+                .with_depends_on(vec!["human_review"]),
+        ];
+        let workflow = WorkflowDefinition::new(steps);
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+
+        // Run until paused
+        let status = runner.run_all(&workflow.id).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Paused);
+
+        // Resume with human input
+        let status = runner
+            .resume(
+                &workflow.id,
+                "human_review",
+                serde_json::json!({"approved": true, "notes": "Looks good"}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Completed);
+
+        let state = runner.get_state(&workflow.id).await.unwrap().unwrap();
+        assert_eq!(state.steps[0].status, StepStatus::Done);
+        assert_eq!(state.steps[1].status, StepStatus::Done);
+        assert_eq!(state.steps[2].status, StepStatus::Done);
+
+        // Verify human input was stored in context for downstream steps
+        let ctx = state.context.as_object().unwrap();
+        let steps_ctx = ctx.get("steps").unwrap().as_object().unwrap();
+        let review_result = steps_ctx.get("human_review").unwrap();
+        assert_eq!(review_result["approved"], true);
+    }
+
+    #[tokio::test]
+    async fn resume_wrong_step_id_fails() {
+        let steps = vec![
+            WorkflowStep::wait_for_input("review", "Review", "Review this"),
+        ];
+        let workflow = WorkflowDefinition::new(steps);
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+
+        let status = runner.run_all(&workflow.id).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Paused);
+
+        let err = runner
+            .resume(&workflow.id, "wrong_id", serde_json::json!({}))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn resume_non_paused_workflow_fails() {
+        let steps = vec![
+            WorkflowStep::api_call("step1", "Step 1", "GET", "/api/data"),
+        ];
+        let workflow = WorkflowDefinition::new(steps);
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+
+        let err = runner
+            .resume(&workflow.id, "step1", serde_json::json!({}))
+            .await;
+        assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn wait_for_input_with_entry_point() {
+        // Workflow with entry point that skips to a wait step
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect", "GET", "/detect"),
+            WorkflowStep::wait_for_input(
+                "confirm_import",
+                "Confirm Import",
+                "Review detected items before importing",
+            )
+            .with_depends_on(vec!["detect"]),
+            WorkflowStep::api_call("import", "Import", "POST", "/import")
+                .with_depends_on(vec!["confirm_import"]),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_entry_points(vec![EntryPoint {
+                id: "review_only".to_string(),
+                label: "Review & Import".to_string(),
+                description: None,
+                starts_at: "confirm_import".to_string(),
+                preset_results: {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "detect".to_string(),
+                        serde_json::json!({"items": ["q1", "q2"]}),
+                    );
+                    m
+                },
+                required_inputs: vec![],
+            }])
+            .apply_entry_point("review_only")
+            .unwrap();
+
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+
+        // detect should be skipped, should pause at confirm_import
+        let status = runner.run_all(&workflow.id).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Paused);
+
+        let state = runner.get_state(&workflow.id).await.unwrap().unwrap();
+        assert_eq!(state.steps[0].status, StepStatus::Skipped); // detect
+        assert_eq!(state.steps[1].status, StepStatus::WaitingForInput); // confirm_import
+
+        // Resume
+        let status = runner
+            .resume(
+                &workflow.id,
+                "confirm_import",
+                serde_json::json!({"confirmed": true}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn multiple_wait_for_input_steps() {
+        let steps = vec![
+            WorkflowStep::api_call("step1", "Step 1", "GET", "/api/data"),
+            WorkflowStep::wait_for_input("review1", "First Review", "Review data")
+                .with_depends_on(vec!["step1"]),
+            WorkflowStep::api_call("step2", "Process", "POST", "/process")
+                .with_depends_on(vec!["review1"]),
+            WorkflowStep::wait_for_input("review2", "Final Review", "Final approval")
+                .with_depends_on(vec!["step2"]),
+            WorkflowStep::api_call("step3", "Submit", "POST", "/submit")
+                .with_depends_on(vec!["review2"]),
+        ];
+        let workflow = WorkflowDefinition::new(steps);
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+
+        // Pause at first review
+        let status = runner.run_all(&workflow.id).await.unwrap();
+        assert_eq!(status, WorkflowStatus::Paused);
+
+        // Resume first review — should run step2 then pause at second review
+        let status = runner
+            .resume(&workflow.id, "review1", serde_json::json!({"ok": true}))
+            .await
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Paused);
+
+        let state = runner.get_state(&workflow.id).await.unwrap().unwrap();
+        assert_eq!(state.steps[2].status, StepStatus::Done); // step2 ran
+        assert_eq!(state.steps[3].status, StepStatus::WaitingForInput); // review2
+
+        // Resume second review — should complete
+        let status = runner
+            .resume(&workflow.id, "review2", serde_json::json!({"approved": true}))
+            .await
+            .unwrap();
+        assert_eq!(status, WorkflowStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn wait_for_input_serialization() {
+        let step = WorkflowStep::wait_for_input("review", "Review", "Please review");
+        let json = serde_json::to_value(&step).unwrap();
+        assert_eq!(json["kind"]["type"], "wait_for_input");
+        assert_eq!(json["kind"]["message"], "Please review");
+
+        let deserialized: WorkflowStep = serde_json::from_value(json).unwrap();
+        match deserialized.kind {
+            StepKind::WaitForInput { message, schema } => {
+                assert_eq!(message, "Please review");
+                assert!(schema.is_none());
+            }
+            _ => panic!("Expected WaitForInput"),
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_for_input_with_schema() {
+        let mut step = WorkflowStep::wait_for_input("review", "Review", "Approve?");
+        if let StepKind::WaitForInput { ref mut schema, .. } = step.kind {
+            *schema = Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "approved": { "type": "boolean" }
+                },
+                "required": ["approved"]
+            }));
+        }
+        let json = serde_json::to_value(&step).unwrap();
+        assert!(json["kind"]["schema"].is_object());
+    }
 }

--- a/distri-workflow/src/tests.rs
+++ b/distri-workflow/src/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::*;
+    use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
@@ -1309,5 +1310,268 @@ mod tests {
         assert_eq!(workflow.steps[0].status, StepStatus::Pending);
         assert!(workflow.steps[0].result.is_none());
         assert!(workflow.steps[0].input.is_some());
+    }
+
+    // ========================================================================
+    // Multi-Entry Point Tests
+    // ========================================================================
+
+    #[test]
+    fn entry_point_skips_unreachable_steps() {
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect docs", "POST", "/detect"),
+            WorkflowStep::api_call("create_content", "Create content", "POST", "/content")
+                .with_depends_on(vec!["detect"]),
+            WorkflowStep::api_call("configure_eval", "Configure eval", "POST", "/eval")
+                .with_depends_on(vec!["create_content"]),
+            WorkflowStep::api_call("grade", "Grade", "POST", "/grade")
+                .with_depends_on(vec!["configure_eval"]),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_entry_points(vec![EntryPoint {
+                id: "grade_only".to_string(),
+                label: "Grade Only".to_string(),
+                description: Some("Start at grading".to_string()),
+                starts_at: "grade".to_string(),
+                preset_results: HashMap::from([
+                    ("configure_eval".to_string(), serde_json::json!({"rubric_id": "r1"})),
+                ]),
+                required_inputs: vec!["activity_id".to_string()],
+            }]);
+
+        let applied = workflow.apply_entry_point("grade_only").unwrap();
+
+        // detect, create_content, configure_eval should be skipped
+        assert_eq!(applied.steps[0].status, StepStatus::Skipped); // detect
+        assert_eq!(applied.steps[1].status, StepStatus::Skipped); // create_content
+        assert_eq!(applied.steps[2].status, StepStatus::Skipped); // configure_eval
+        assert_eq!(applied.steps[3].status, StepStatus::Pending); // grade — should run
+
+        // configure_eval should have preset result
+        assert_eq!(
+            applied.steps[2].result,
+            Some(serde_json::json!({"rubric_id": "r1"}))
+        );
+    }
+
+    #[test]
+    fn entry_point_mid_workflow() {
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect", "POST", "/detect"),
+            WorkflowStep::api_call("content", "Content", "POST", "/content")
+                .with_depends_on(vec!["detect"]),
+            WorkflowStep::api_call("eval", "Eval", "POST", "/eval")
+                .with_depends_on(vec!["content"]),
+            WorkflowStep::api_call("grade", "Grade", "POST", "/grade")
+                .with_depends_on(vec!["eval"]),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_entry_points(vec![EntryPoint {
+                id: "existing_activity".to_string(),
+                label: "Existing Activity".to_string(),
+                description: None,
+                starts_at: "eval".to_string(),
+                preset_results: HashMap::new(),
+                required_inputs: vec![],
+            }]);
+
+        let applied = workflow.apply_entry_point("existing_activity").unwrap();
+        assert_eq!(applied.steps[0].status, StepStatus::Skipped); // detect
+        assert_eq!(applied.steps[1].status, StepStatus::Skipped); // content
+        assert_eq!(applied.steps[2].status, StepStatus::Pending); // eval
+        assert_eq!(applied.steps[3].status, StepStatus::Pending); // grade
+    }
+
+    #[test]
+    fn entry_point_not_found_returns_error() {
+        let workflow = WorkflowDefinition::new(vec![
+            WorkflowStep::api_call("s1", "S1", "GET", "/"),
+        ]);
+        assert!(workflow.apply_entry_point("nonexistent").is_err());
+    }
+
+    #[test]
+    fn entry_point_populates_context() {
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect", "POST", "/detect"),
+            WorkflowStep::api_call("grade", "Grade", "POST", "/grade")
+                .with_depends_on(vec!["detect"]),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_entry_points(vec![EntryPoint {
+                id: "grade_only".to_string(),
+                label: "Grade Only".to_string(),
+                description: None,
+                starts_at: "grade".to_string(),
+                preset_results: HashMap::from([
+                    ("detect".to_string(), serde_json::json!({"questions": [1, 2, 3]})),
+                ]),
+                required_inputs: vec![],
+            }]);
+
+        let applied = workflow.apply_entry_point("grade_only").unwrap();
+
+        // Context should have preset results under steps namespace
+        let ctx_steps = applied.context.get("steps").unwrap();
+        assert_eq!(ctx_steps["detect"]["questions"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[tokio::test]
+    async fn entry_point_runs_from_mid_workflow() {
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect", "POST", "/detect"),
+            WorkflowStep::api_call("content", "Content", "POST", "/content")
+                .with_depends_on(vec!["detect"]),
+            WorkflowStep::api_call("eval", "Eval", "POST", "/eval")
+                .with_depends_on(vec!["content"]),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_id("ep-test")
+            .with_entry_points(vec![EntryPoint {
+                id: "from_eval".to_string(),
+                label: "From Eval".to_string(),
+                description: None,
+                starts_at: "eval".to_string(),
+                preset_results: HashMap::new(),
+                required_inputs: vec![],
+            }]);
+
+        let applied = workflow.apply_entry_point("from_eval").unwrap();
+        let store = InMemoryStore::new();
+        store.save(&applied).await.unwrap();
+
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+        let status = runner.run_all("ep-test").await.unwrap();
+
+        assert_eq!(status, WorkflowStatus::Completed);
+    }
+
+    // ========================================================================
+    // Skip-If Tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn skip_if_skips_step_when_condition_true() {
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect", "POST", "/detect")
+                .with_skip_if("{input.activity_id}"),
+            WorkflowStep::api_call("grade", "Grade", "POST", "/grade"),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_id("skip-test")
+            .with_input(serde_json::json!({"activity_id": "existing-123"}))
+            .unwrap();
+
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+        let status = runner.run_all("skip-test").await.unwrap();
+
+        assert_eq!(status, WorkflowStatus::Completed);
+        let final_wf = runner.get_state("skip-test").await.unwrap().unwrap();
+        assert_eq!(final_wf.steps[0].status, StepStatus::Skipped);
+        assert_eq!(final_wf.steps[1].status, StepStatus::Done);
+    }
+
+    #[tokio::test]
+    async fn skip_if_runs_step_when_condition_false() {
+        let steps = vec![
+            WorkflowStep::api_call("detect", "Detect", "POST", "/detect")
+                .with_skip_if("{input.activity_id}"),
+            WorkflowStep::api_call("grade", "Grade", "POST", "/grade"),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_id("no-skip-test")
+            .with_input(serde_json::json!({}))
+            .unwrap();
+
+        let store = InMemoryStore::new();
+        store.save(&workflow).await.unwrap();
+
+        let runner = WorkflowRunner::new(store, MockExecutor::new());
+        let status = runner.run_all("no-skip-test").await.unwrap();
+
+        assert_eq!(status, WorkflowStatus::Completed);
+        let final_wf = runner.get_state("no-skip-test").await.unwrap().unwrap();
+        assert_eq!(final_wf.steps[0].status, StepStatus::Done);
+        assert_eq!(final_wf.steps[1].status, StepStatus::Done);
+    }
+
+    #[test]
+    fn skip_if_negation_works() {
+        let ctx = serde_json::json!({
+            "input": { "mode": "generate" },
+            "steps": {},
+            "env": {}
+        });
+
+        // {input.mode} is truthy
+        assert!(crate::resolve::evaluate_skip_condition("{input.mode}", &ctx));
+        // !{input.mode} is falsy
+        assert!(!crate::resolve::evaluate_skip_condition("!{input.mode}", &ctx));
+        // {input.nonexistent} is falsy
+        assert!(!crate::resolve::evaluate_skip_condition("{input.nonexistent}", &ctx));
+        // !{input.nonexistent} is truthy
+        assert!(crate::resolve::evaluate_skip_condition("!{input.nonexistent}", &ctx));
+    }
+
+    #[test]
+    fn skip_if_equality_check() {
+        let ctx = serde_json::json!({
+            "input": { "mode": "pick" },
+            "steps": {},
+            "env": {}
+        });
+
+        assert!(crate::resolve::evaluate_skip_condition("{input.mode} == \"pick\"", &ctx));
+        assert!(!crate::resolve::evaluate_skip_condition("{input.mode} == \"generate\"", &ctx));
+        assert!(crate::resolve::evaluate_skip_condition("{input.mode} != \"generate\"", &ctx));
+    }
+
+    #[test]
+    fn entry_point_serializes_roundtrip() {
+        let steps = vec![
+            WorkflowStep::api_call("s1", "S1", "GET", "/"),
+            WorkflowStep::api_call("s2", "S2", "GET", "/").with_depends_on(vec!["s1"]),
+        ];
+
+        let workflow = WorkflowDefinition::new(steps)
+            .with_entry_points(vec![EntryPoint {
+                id: "from_s2".to_string(),
+                label: "From S2".to_string(),
+                description: Some("Skip S1".to_string()),
+                starts_at: "s2".to_string(),
+                preset_results: HashMap::from([
+                    ("s1".to_string(), serde_json::json!({"done": true})),
+                ]),
+                required_inputs: vec!["data".to_string()],
+            }]);
+
+        let json = serde_json::to_value(&workflow).unwrap();
+        let deserialized: WorkflowDefinition = serde_json::from_value(json).unwrap();
+
+        assert_eq!(deserialized.entry_points.len(), 1);
+        assert_eq!(deserialized.entry_points[0].id, "from_s2");
+        assert_eq!(deserialized.entry_points[0].starts_at, "s2");
+        assert_eq!(deserialized.entry_points[0].required_inputs, vec!["data"]);
+    }
+
+    #[test]
+    fn skip_if_serializes_roundtrip() {
+        let step = WorkflowStep::api_call("s1", "S1", "GET", "/")
+            .with_skip_if("{input.existing_id}");
+
+        let json = serde_json::to_value(&step).unwrap();
+        assert_eq!(json["skip_if"], "{input.existing_id}");
+
+        let deserialized: WorkflowStep = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.skip_if.as_deref(), Some("{input.existing_id}"));
     }
 }

--- a/distri-workflow/src/types.rs
+++ b/distri-workflow/src/types.rs
@@ -31,6 +31,10 @@ pub struct WorkflowDefinition {
     /// How workflow state is checkpointed. Defaults to Internal.
     #[serde(default)]
     pub checkpoint: CheckpointStrategy,
+    /// Named entry points for multi-entry workflows.
+    /// Each entry point specifies a starting step and optional pre-populated state.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entry_points: Vec<EntryPoint>,
     #[serde(default = "default_now")]
     pub created_at: DateTime<Utc>,
     #[serde(default = "default_now")]
@@ -56,6 +60,7 @@ impl WorkflowDefinition {
             notes: vec![],
             input_schema: None,
             checkpoint: CheckpointStrategy::default(),
+            entry_points: vec![],
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
@@ -76,9 +81,97 @@ impl WorkflowDefinition {
         self
     }
 
+    pub fn with_entry_points(mut self, entry_points: Vec<EntryPoint>) -> Self {
+        self.entry_points = entry_points;
+        self
+    }
+
+    /// Get an entry point by ID.
+    pub fn entry_point(&self, id: &str) -> Option<&EntryPoint> {
+        self.entry_points.iter().find(|ep| ep.id == id)
+    }
+
+    /// Apply an entry point: mark steps before `starts_at` as Skipped,
+    /// pre-populate results from `preset_results`, and return the modified workflow.
+    pub fn apply_entry_point(mut self, entry_point_id: &str) -> Result<Self, String> {
+        let ep = self
+            .entry_points
+            .iter()
+            .find(|ep| ep.id == entry_point_id)
+            .ok_or_else(|| format!("Entry point '{}' not found", entry_point_id))?
+            .clone();
+
+        // Validate starts_at step exists
+        if !self.steps.iter().any(|s| s.id == ep.starts_at) {
+            return Err(format!(
+                "Entry point '{}' references step '{}' which does not exist",
+                entry_point_id, ep.starts_at
+            ));
+        }
+
+        // Collect steps that are "before" starts_at in the DAG.
+        // A step is before if starts_at does not transitively depend on it,
+        // OR it's simply not reachable from starts_at's dependency chain.
+        // Simpler approach: mark all steps as Skipped that are NOT starts_at
+        // and NOT reachable from starts_at via depends_on chain.
+        let reachable = self.reachable_from(&ep.starts_at);
+
+        for step in &mut self.steps {
+            if !reachable.contains(&step.id) {
+                step.status = StepStatus::Skipped;
+                // Apply preset result if available
+                if let Some(result) = ep.preset_results.get(&step.id) {
+                    step.result = Some(result.clone());
+                }
+            }
+        }
+
+        // Pre-populate context with preset results so downstream steps can reference them
+        if let Some(ctx) = self.context.as_object_mut() {
+            let steps = ctx
+                .entry("steps")
+                .or_insert(serde_json::json!({}))
+                .as_object_mut()
+                .expect("steps must be an object");
+            for (step_id, result) in &ep.preset_results {
+                steps.insert(step_id.clone(), result.clone());
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// Find all step IDs reachable from the given step (inclusive) by following depends_on forward.
+    /// "Reachable from X" means X itself, plus any step that X depends on or that depends on X transitively.
+    fn reachable_from(&self, start_step_id: &str) -> std::collections::HashSet<String> {
+        use std::collections::{HashSet, VecDeque};
+
+        let mut reachable = HashSet::new();
+        let mut queue = VecDeque::new();
+        queue.push_back(start_step_id.to_string());
+
+        // Forward: start_step and everything that depends on it (downstream)
+        while let Some(current) = queue.pop_front() {
+            if !reachable.insert(current.clone()) {
+                continue;
+            }
+            // Find steps that depend on `current`
+            for step in &self.steps {
+                if step.depends_on.contains(&current) && !reachable.contains(&step.id) {
+                    queue.push_back(step.id.clone());
+                }
+            }
+        }
+
+        reachable
+    }
+
     /// Merge external input into the workflow context.
     /// Initialize workflow with validated input. Input is validated against
     /// `input_schema` if present, then merged into context.
+    ///
+    /// Input is stored both at the top level (backward compat) and under the
+    /// `input` namespace so that `{input.X}` references work in skip_if and templates.
     pub fn with_input(mut self, input: serde_json::Value) -> Result<Self, String> {
         // Validate input against schema if present
         if let Some(ref schema_value) = self.input_schema {
@@ -94,11 +187,13 @@ impl WorkflowDefinition {
             }
         }
 
-        // Merge input into context
+        // Merge input into context (both flat for backward compat and under "input" namespace)
         if let (Some(ctx), Some(inp)) = (self.context.as_object_mut(), input.as_object()) {
             for (k, v) in inp {
                 ctx.insert(k.clone(), v.clone());
             }
+            // Also store under "input" namespace for {input.X} references
+            ctx.insert("input".to_string(), input.clone());
         }
 
         self.status = WorkflowStatus::Running;
@@ -115,6 +210,7 @@ impl WorkflowDefinition {
     }
 
     /// Get all steps that can run now (pending steps with all dependencies met).
+    /// Dependencies are "met" if the step is Done or Skipped (entry point skips count).
     /// This is a pure query — it does not mutate.
     pub fn runnable_steps(&self) -> Vec<(usize, &WorkflowStep)> {
         let mut runnable = vec![];
@@ -123,11 +219,12 @@ impl WorkflowDefinition {
                 continue;
             }
 
-            // Check if all dependencies are done
+            // Check if all dependencies are done or skipped
             let deps_met = step.depends_on.iter().all(|dep_id| {
-                self.steps
-                    .iter()
-                    .any(|s| &s.id == dep_id && s.status == StepStatus::Done)
+                self.steps.iter().any(|s| {
+                    &s.id == dep_id
+                        && matches!(s.status, StepStatus::Done | StepStatus::Skipped)
+                })
             });
 
             if deps_met {
@@ -273,6 +370,32 @@ impl WorkflowDefinition {
 }
 
 // ============================================================================
+// Entry Point — named starting positions for multi-entry workflows
+// ============================================================================
+
+/// A named entry point into a workflow.
+/// Allows workflows to be started at different steps depending on context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntryPoint {
+    /// Unique identifier for this entry point (e.g., "import_from_docs", "grade_only").
+    pub id: String,
+    /// Human-readable label.
+    pub label: String,
+    /// Optional description of when to use this entry point.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The step ID where execution begins.
+    pub starts_at: String,
+    /// Pre-populated step results for steps that are skipped.
+    /// Maps step_id → result value. These steps are marked Done before execution starts.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub preset_results: HashMap<String, serde_json::Value>,
+    /// Required input fields for this entry point (for UI/validation).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_inputs: Vec<String>,
+}
+
+// ============================================================================
 // Workflow Step
 // ============================================================================
 
@@ -311,6 +434,11 @@ pub struct WorkflowStep {
     /// If omitted, the step receives the full execution context.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input: Option<serde_json::Value>,
+    /// Skip this step if the expression evaluates to true against the workflow context.
+    /// Expression format: `{input.field_name}` — truthy check (field exists and is not null/false/empty).
+    /// Supports negation: `!{input.field_name}` — skip if field is absent/falsy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_if: Option<String>,
 }
 
 impl WorkflowStep {
@@ -328,6 +456,7 @@ impl WorkflowStep {
             execution: StepExecution::Sequential,
             requires: vec![],
             input: None,
+            skip_if: None,
         }
     }
 
@@ -467,6 +596,11 @@ impl WorkflowStep {
 
     pub fn with_input_mapping(mut self, input: serde_json::Value) -> Self {
         self.input = Some(input);
+        self
+    }
+
+    pub fn with_skip_if(mut self, expression: &str) -> Self {
+        self.skip_if = Some(expression.to_string());
         self
     }
 }

--- a/distri-workflow/src/types.rs
+++ b/distri-workflow/src/types.rs
@@ -244,6 +244,58 @@ impl WorkflowDefinition {
         })
     }
 
+    /// Check if the workflow is paused waiting for human/external input.
+    pub fn is_waiting_for_input(&self) -> bool {
+        self.steps
+            .iter()
+            .any(|s| s.status == StepStatus::WaitingForInput)
+    }
+
+    /// Get the step that is waiting for input, if any.
+    pub fn waiting_step(&self) -> Option<(usize, &WorkflowStep)> {
+        self.steps
+            .iter()
+            .enumerate()
+            .find(|(_, s)| s.status == StepStatus::WaitingForInput)
+    }
+
+    /// Resume a paused workflow by providing input for the waiting step.
+    /// Marks the step as Done with the provided result and sets workflow back to Running.
+    pub fn resume_step(
+        &mut self,
+        step_id: &str,
+        result: serde_json::Value,
+    ) -> Result<usize, String> {
+        let idx = self
+            .steps
+            .iter()
+            .position(|s| s.id == step_id && s.status == StepStatus::WaitingForInput)
+            .ok_or_else(|| {
+                format!(
+                    "Step '{}' not found or not in waiting_for_input state",
+                    step_id
+                )
+            })?;
+
+        self.steps[idx].status = StepStatus::Done;
+        self.steps[idx].result = Some(result.clone());
+        self.steps[idx].completed_at = Some(Utc::now());
+
+        // Store result in context so downstream steps can reference it
+        if let Some(ctx) = self.context.as_object_mut() {
+            let steps = ctx
+                .entry("steps")
+                .or_insert(serde_json::json!({}))
+                .as_object_mut()
+                .expect("steps must be an object");
+            steps.insert(step_id.to_string(), result);
+        }
+
+        self.status = WorkflowStatus::Running;
+        self.updated_at = Utc::now();
+        Ok(idx)
+    }
+
     /// Check if the workflow is stuck — remaining steps are all blocked, no forward progress possible.
     pub fn is_stuck(&self) -> bool {
         let has_blocked = self.steps.iter().any(|s| s.status == StepStatus::Blocked);
@@ -544,6 +596,17 @@ impl WorkflowStep {
         )
     }
 
+    pub fn wait_for_input(id: &str, label: &str, message: &str) -> Self {
+        Self::new_step(
+            id,
+            label,
+            StepKind::WaitForInput {
+                message: message.to_string(),
+                schema: None,
+            },
+        )
+    }
+
     pub fn with_body(mut self, body: serde_json::Value) -> Self {
         if let StepKind::ApiCall {
             body: ref mut b, ..
@@ -677,6 +740,17 @@ pub enum StepKind {
 
     /// No-op / marker step (for documentation or manual checkpoints)
     Checkpoint { message: String },
+
+    /// Pause execution and wait for external/human input before continuing.
+    /// The workflow saves state and stops. A resume call provides the input
+    /// as the step result and continues from here.
+    WaitForInput {
+        /// Message to display to the human (what input is needed)
+        message: String,
+        /// Optional JSON Schema describing the expected input shape
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        schema: Option<serde_json::Value>,
+    },
 }
 
 // ============================================================================
@@ -824,6 +898,8 @@ pub enum StepStatus {
     Done,
     Failed,
     Skipped,
+    /// Step is waiting for external/human input. Workflow is paused.
+    WaitingForInput,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -947,6 +1023,14 @@ pub enum WorkflowEvent {
         step_id: String,
         step_label: String,
         error: String,
+    },
+    /// A step is waiting for external/human input
+    StepWaiting {
+        workflow_id: String,
+        step_id: String,
+        step_label: String,
+        message: String,
+        schema: Option<serde_json::Value>,
     },
     /// Workflow completed (all steps done or failed)
     WorkflowCompleted {

--- a/distri/src/workflow_executor.rs
+++ b/distri/src/workflow_executor.rs
@@ -153,6 +153,17 @@ impl StepExecutor for DistriStepExecutor {
                 "evaluated": true,
                 "message": "Condition evaluation is placeholder"
             }))),
+
+            StepKind::WaitForInput { message, schema } => Ok(StepResult {
+                status: StepStatus::WaitingForInput,
+                result: Some(json!({
+                    "waiting": true,
+                    "message": message,
+                    "schema": schema,
+                })),
+                error: None,
+                context_updates: None,
+            }),
         }
     }
 

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -74,6 +74,15 @@ impl EventSink for ContextEventSink {
                 "\n**Workflow {:?}** — {} done, {} failed\n",
                 status, steps_done, steps_failed
             ),
+            WorkflowEvent::StepWaiting {
+                step_id,
+                step_label,
+                message,
+                ..
+            } => format!(
+                "\n**Waiting for input:** `{}` — {} — {}\n",
+                step_id, step_label, message
+            ),
         };
 
         self.context.emit(WorkflowAgent::emit_text(&text)).await;
@@ -239,6 +248,21 @@ impl StepExecutor for ContextStepExecutor {
                 "expression": expression,
                 "evaluated": true
             }))),
+
+            StepKind::WaitForInput { message, schema } => {
+                // This should be intercepted by the executor before reaching here,
+                // but handle defensively.
+                Ok(StepResult {
+                    status: StepStatus::WaitingForInput,
+                    result: Some(serde_json::json!({
+                        "waiting": true,
+                        "message": message,
+                        "schema": schema,
+                    })),
+                    error: None,
+                    context_updates: None,
+                })
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **distri-workflow (Rust):** Add `EntryPoint` struct, `entry_points` on `WorkflowDefinition`, `skip_if` on `WorkflowStep`, `evaluate_skip_condition()`, `apply_entry_point()`. Update executor to evaluate skip_if before running steps. Update `runnable_steps()` to treat Skipped deps as met. 17 new tests (85 total, all passing).
- **distri-home:** Add `WorkflowEntryPointSelector` React component for choosing workflow entry points with step preview, required inputs hints, and visual step status icons.

### Key design decisions

- Entry points use `starts_at` to identify the first step, then `reachable_from()` to determine which steps to keep vs skip
- `preset_results` lets entry points pre-populate step results so downstream `{steps.X.Y}` references resolve correctly
- `skip_if` expressions support `{input.field}` (truthy), `!{input.field}` (negation), `== "value"` (equality), `!= "value"` (inequality)
- `with_input()` now stores input under both flat context (backward compat) and `input` namespace for template resolution

## Test plan

- [x] `cargo test -p distri-workflow` — 85 tests pass
- [ ] Verify entry point skips correct steps in DAG
- [ ] Verify skip_if evaluates correctly against workflow context
- [ ] Verify WorkflowEntryPointSelector renders entry point cards
- [ ] Verify serialization roundtrip for entry_points and skip_if

https://claude.ai/code/session_01LujMqScYWaqfUcqoBDndAU