### PR TITLE
fix(text-formatter): take_output clones instead of draining

### DIFF
--- a/distri-formatter/src/text.rs
+++ b/distri-formatter/src/text.rs
@@ -308,7 +308,8 @@ impl Formatter for TextFormatter {
         if self.output.is_empty() {
             RendererOutput::None
         } else {
-            RendererOutput::Text(std::mem::take(&mut self.output))
+            // Clone, don't take — final_content() needs the accumulated output.
+            RendererOutput::Text(self.output.clone())
         }
     }
 


### PR DESCRIPTION
TextFormatter.take_output() was using std::mem::take which drained self.output, making final_content() return empty. TelegramRenderer correctly clones. Now TextFormatter does the same.