### PR TITLE
Flatten dynamic_values in TemplateData serialization

### DIFF
--- a/distri-types/src/prompt.rs
+++ b/distri-types/src/prompt.rs
@@ -33,6 +33,7 @@ pub struct TemplateData<'a> {
     pub task: String,
     pub scratchpad: String,
     pub dynamic_sections: Vec<PromptSection>,
+    #[serde(flatten)]
     pub dynamic_values: std::collections::HashMap<String, serde_json::Value>,
     /// Session values fetched from the session store - available in templates as {{session.key}}
     pub session_values: std::collections::HashMap<String, serde_json::Value>,


### PR DESCRIPTION
## Summary
Added `#[serde(flatten)]` attribute to the `dynamic_values` field in the `TemplateData` struct to flatten its contents during serialization/deserialization.

## Key Changes
- Added `#[serde(flatten)]` annotation to `dynamic_values: HashMap<String, serde_json::Value>` in the `TemplateData` struct

## Implementation Details
This change modifies how `dynamic_values` are serialized when `TemplateData` is converted to JSON or other serde-supported formats. Instead of nesting the HashMap under a `dynamic_values` key, the individual key-value pairs will be flattened into the parent object. This allows template variables to be accessed directly at the top level rather than under a nested namespace, improving the ergonomics of template variable access.

https://claude.ai/code/session_014DF13NXppXAze3LL1AxTwi