### PR TITLE
Add OpenAPI documentation and smoke tests for API endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,9 @@ dependencies = [
  "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-actix-web",
+ "utoipa-scalar",
  "uuid",
 ]
 
@@ -1991,6 +1994,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utoipa",
  "uuid",
 ]
 
@@ -6481,6 +6485,54 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-actix-web"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7eda9c23c05af0fb812f6a177514047331dac4851a2c8e9c4b895d6d826967f"
+dependencies = [
+ "actix-service",
+ "actix-web",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-scalar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
+dependencies = [
+ "actix-web",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ tokio-util = { version = "0.7", features = ["full"] }
 uuid = { version = "1.0", features = ["v4", "js"] }
 schemars = { version = "1.0.4", features = ["uuid1"] }
 jsonschema = "0.45"
+utoipa = { version = "5", features = ["actix_extras", "chrono", "uuid"] }
+utoipa-actix-web = "0.1"
+utoipa-scalar = { version = "0.3", features = ["actix-web"] }
 
 # Actix web dependencies (standardized across distri-server and distri-auth)
 actix-web = "4.4"

--- a/distri-types/Cargo.toml
+++ b/distri-types/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = { workspace = true }
 futures = { workspace = true }
 jsonschema = { workspace = true }
 schemars = { workspace = true }
+utoipa = { workspace = true }
 secrecy = { version = "0.10.3", features = ["serde"] }
 uuid = { version = "1.13.1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/distri-types/src/configuration/config.rs
+++ b/distri-types/src/configuration/config.rs
@@ -2,8 +2,9 @@ use crate::a2a::{AgentCapabilities, AgentProvider, SecurityScheme};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, ToSchema)]
 pub struct StoreConfig {
     /// Metadata store (agent_config, tool_auth) - persistent across sessions
     #[serde(default)]
@@ -17,7 +18,7 @@ pub struct StoreConfig {
     #[serde(default)]
     pub session: SessionStoreConfig,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq, Hash, ToSchema)]
 #[serde(tag = "type", content = "config", rename_all = "lowercase")]
 pub enum StoreType {
     #[default]
@@ -38,7 +39,7 @@ impl StoreType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct MetadataStoreConfig {
     #[serde(default)]
     pub store_type: StoreType,
@@ -55,7 +56,7 @@ impl Default for MetadataStoreConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct MemoryStoreConfig {
     #[serde(default)]
     pub store_type: StoreType,
@@ -83,7 +84,7 @@ impl Default for MemoryStoreConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct SessionStoreConfig {
     /// If true, creates a new ephemeral in-memory SQLite connection for each thread execution
     /// When ephemeral, store_type and db_config are ignored (always uses in-memory SQLite)
@@ -111,7 +112,7 @@ impl Default for SessionStoreConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct PostgresConfig {
     pub database_url: String,
     #[serde(default = "default_postgres_max_connections")]
@@ -140,7 +141,7 @@ fn default_postgres_idle_timeout() -> u64 {
     600
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct DbConnectionConfig {
     #[serde(default = "default_database_url")]
     pub database_url: String,
@@ -166,7 +167,7 @@ fn default_connections() -> u32 {
     3
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 #[serde(tag = "type", content = "config", rename_all = "lowercase")]
 pub enum ObjectStorageConfig {
     /// Local filesystem storage
@@ -219,7 +220,7 @@ fn default_max_results() -> usize {
     10
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct ServerConfig {
     #[serde(default = "default_server_url")]
     pub base_url: String,
@@ -228,16 +229,19 @@ pub struct ServerConfig {
     #[serde(default)]
     pub host: Option<String>,
     #[serde(default = "default_agent_provider")]
+    #[schema(value_type = Object)]
     pub agent_provider: AgentProvider,
     #[serde(default)]
     pub default_input_modes: Vec<String>,
     #[serde(default)]
     pub default_output_modes: Vec<String>,
     #[serde(default)]
+    #[schema(value_type = Object)]
     pub security_schemes: HashMap<String, SecurityScheme>,
     #[serde(default)]
     pub security: Vec<HashMap<String, Vec<String>>>,
     #[serde(default = "default_capabilities")]
+    #[schema(value_type = Object)]
     pub capabilities: AgentCapabilities,
     #[serde(default = "default_preferred_transport")]
     pub preferred_transport: Option<String>,
@@ -291,9 +295,10 @@ fn default_preferred_transport() -> Option<String> {
     Some("JSONRPC".to_string())
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
 pub struct ExternalMcpServer {
     pub name: String,
     #[serde(default, flatten)]
+    #[schema(value_type = Object)]
     pub config: crate::McpServerMetadata,
 }

--- a/distri-types/src/configuration/manifest.rs
+++ b/distri-types/src/configuration/manifest.rs
@@ -3,13 +3,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
 use tokio::fs;
+use utoipa::ToSchema;
+
 
 // Import config types
 use crate::agent::ModelSettings;
 use crate::configuration::config::{ExternalMcpServer, ServerConfig, StoreConfig};
 
 /// User configuration from distri.toml file
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct DistriServerConfig {
     pub name: String,
     pub version: String,
@@ -39,8 +41,10 @@ pub struct DistriServerConfig {
     pub server: Option<ServerConfig>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<Object>)]
     pub model_settings: Option<ModelSettings>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<Object>)]
     pub analysis_model_settings: Option<ModelSettings>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -54,7 +58,7 @@ pub struct DistriServerConfig {
 }
 
 /// Build configuration for custom build commands
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct BuildConfig {
     /// Build command to execute
     pub command: String,
@@ -72,7 +76,7 @@ impl DistriServerConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "type")]
 #[serde(rename_all = "lowercase")]
 pub struct EntryPoints {
@@ -90,22 +94,22 @@ impl EntryPoints {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct EngineConfig {
     pub engine: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct AuthorsConfig {
     pub primary: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryConfig {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct LockFile {
     pub packages: HashMap<String, String>,
     pub sources: HashMap<String, String>,

--- a/distri-types/src/configuration/overrides.rs
+++ b/distri-types/src/configuration/overrides.rs
@@ -1,8 +1,9 @@
 use crate::dynamic_tool::DynamicToolFactory;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Overrides for agent definition - only the most commonly overridden fields
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct DefinitionOverrides {
     /// Override the model (e.g., "gpt-4o", "gpt-4.1-mini")
     pub model: Option<String>,

--- a/distri-types/src/configuration/package.rs
+++ b/distri-types/src/configuration/package.rs
@@ -3,9 +3,10 @@ use crate::agent::StandardDefinition;
 use crate::configuration::manifest::DistriServerConfig;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use utoipa::ToSchema;
 
 /// Tool definition ready for DAP registration with runtime info
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PluginToolDefinition {
     pub name: String,
     pub package_name: String,
@@ -13,11 +14,12 @@ pub struct PluginToolDefinition {
     #[serde(default)]
     pub parameters: serde_json::Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<Object>)]
     pub auth: Option<crate::auth::AuthRequirement>,
 }
 
 /// Cloud-specific metadata for agents (optional, only present in cloud responses)
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct AgentCloudMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<uuid::Uuid>,
@@ -29,9 +31,10 @@ pub struct AgentCloudMetadata {
     pub is_owner: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct AgentConfigWithTools {
     #[serde(flatten)]
+    #[schema(value_type = Object)]
     pub agent: AgentConfig,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub resolved_tools: Vec<ToolDefinition>,
@@ -43,10 +46,11 @@ pub struct AgentConfigWithTools {
 }
 
 /// Unified agent configuration enum
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "agent_type", rename_all = "snake_case")]
 pub enum AgentConfig {
     /// Standard markdown-based agent
+    #[schema(value_type = Object)]
     StandardAgent(StandardDefinition),
     /// Workflow-based agent — executes a workflow DAG instead of an LLM loop
     WorkflowAgent(WorkflowAgentDefinition),
@@ -55,7 +59,7 @@ pub enum AgentConfig {
 /// Definition for a workflow-based agent.
 /// The workflow definition is stored as JSON to avoid crate dependency on distri-workflow.
 /// Deserialize to `distri_workflow::WorkflowDefinition` at execution time.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct WorkflowAgentDefinition {
     pub name: String,
     pub description: String,
@@ -136,20 +140,23 @@ impl AgentConfig {
 }
 
 /// Agent definition ready for DAP registration with runtime info
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PluginAgentDefinition {
     pub name: String,
     pub package_name: String,
     pub description: String,
+    #[schema(value_type = String)]
     pub file_path: PathBuf,
     /// The full agent configuration (supports all agent types)
+    #[schema(value_type = Object)]
     pub agent_config: AgentConfig,
 }
 
 /// Built DAP package artifact ready for registration in distri
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PluginArtifact {
     pub name: String,
+    #[schema(value_type = String)]
     pub path: PathBuf,
     pub configuration: crate::configuration::manifest::DistriServerConfig,
     pub tools: Vec<PluginToolDefinition>,

--- a/distri-types/src/configuration/registry.rs
+++ b/distri-types/src/configuration/registry.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 /// Registry package download response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPackageResponse {
     pub package: String,
     pub version: String,
@@ -14,14 +15,14 @@ pub struct RegistryPackageResponse {
 }
 
 /// Registry package metadata
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPackageMetadata {
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub is_yanked: bool,
 }
 
 /// Registry package version information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPackageVersion {
     pub id: Uuid,
     pub package_id: Uuid,
@@ -35,7 +36,7 @@ pub struct RegistryPackageVersion {
 }
 
 /// Registry package information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPackage {
     pub id: Uuid,
     pub name: String,
@@ -46,7 +47,7 @@ pub struct RegistryPackage {
 }
 
 /// Registry package detail with versions
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPackageDetail {
     pub id: Uuid,
     pub name: String,
@@ -59,7 +60,7 @@ pub struct RegistryPackageDetail {
 }
 
 /// Registry search query parameters
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistrySearchQuery {
     pub q: Option<String>,
     pub page: Option<i64>,
@@ -68,7 +69,7 @@ pub struct RegistrySearchQuery {
 }
 
 /// Registry search results
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistrySearchResults {
     pub packages: Vec<RegistryPackage>,
     pub total: i64,
@@ -78,7 +79,7 @@ pub struct RegistrySearchResults {
 }
 
 /// Registry publish request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPublishRequest {
     pub name: String,
     pub version: String,
@@ -87,7 +88,7 @@ pub struct RegistryPublishRequest {
 }
 
 /// Registry publish response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryPublishResponse {
     pub message: String,
     pub package_id: Uuid,
@@ -95,13 +96,13 @@ pub struct RegistryPublishResponse {
 }
 
 /// Registry yank request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryYankRequest {
     pub yanked: bool,
 }
 
 /// Registry yank response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryYankResponse {
     pub message: String,
     pub version: String,
@@ -109,14 +110,14 @@ pub struct RegistryYankResponse {
 }
 
 /// Registry API error response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryApiError {
     pub error: String,
     pub message: String,
 }
 
 /// Registry user information
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryUserInfo {
     pub id: Uuid,
     pub email: String,
@@ -125,14 +126,14 @@ pub struct RegistryUserInfo {
 }
 
 /// Registry login request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryLoginRequest {
     pub email: String,
     pub password: String,
 }
 
 /// Registry login response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryLoginResponse {
     pub message: String,
     pub token: String,
@@ -140,7 +141,7 @@ pub struct RegistryLoginResponse {
 }
 
 /// Registry register request
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RegistryRegisterRequest {
     pub email: String,
     pub password: String,

--- a/distri-types/src/connections.rs
+++ b/distri-types/src/connections.rs
@@ -1,15 +1,17 @@
 use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionAuthType {
     OAuth2,
     Secret,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ConnectionStatus {
     Connected,
@@ -52,7 +54,7 @@ impl std::str::FromStr for ConnectionStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct Connection {
     pub id: Uuid,
     pub workspace_id: Uuid,
@@ -65,7 +67,7 @@ pub struct Connection {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct NewConnection {
     pub workspace_id: Uuid,
     pub skill_id: Uuid,
@@ -76,7 +78,7 @@ pub struct NewConnection {
 }
 
 /// Typed OAuth token — replaces raw serde_json::Value.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct ConnectionToken {
     pub access_token: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/distri-types/src/core.rs
+++ b/distri-types/src/core.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 use serde_json::{self, Value, json};
 use std::default::Default;
 use std::{collections::HashMap, time::SystemTime};
@@ -10,7 +11,7 @@ use crate::filesystem::FileMetadata;
 use crate::events::AgentEventType;
 
 /// Token usage breakdown from an LLM call.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema, ToSchema)]
 pub struct TokenUsage {
     #[serde(default)]
     pub input_tokens: u32,
@@ -21,7 +22,7 @@ pub struct TokenUsage {
 }
 
 /// External tool that delegates execution to the frontend
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub struct ExternalTool {
     pub name: String,
     pub description: String,
@@ -72,7 +73,7 @@ impl crate::Tool for ExternalTool {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
 pub struct ToolDefinition {
     pub name: String,
     pub description: String,
@@ -102,7 +103,7 @@ impl From<ToolDefinition> for async_openai::types::chat::ChatCompletionTools {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MessageRole {
     /// Represents a system message.
@@ -159,7 +160,7 @@ impl Part {
 }
 
 /// Instruction for how to handle additional parts
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 #[derive(Default)]
 pub enum AdditionalPartsInstruction {
@@ -172,9 +173,10 @@ pub enum AdditionalPartsInstruction {
 
 /// Structure for managing additional user message parts
 /// This allows control over how parts are added and whether artifacts should be expanded
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default, ToSchema)]
 pub struct AdditionalParts {
     /// The parts to include in the user message
+    #[schema(value_type = Vec<Object>)]
     pub parts: Vec<Part>,
     /// Whether to replace or append to existing parts
     #[serde(default)]
@@ -186,7 +188,7 @@ pub struct AdditionalParts {
 
 /// Metadata for individual message parts.
 /// Used to control part behavior such as persistence.
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default, PartialEq, ToSchema)]
 pub struct PartMetadata {
     /// If false, this part will be filtered out before saving to the database.
     /// Useful for ephemeral/dynamic content that should only be sent in the current turn.
@@ -203,11 +205,12 @@ fn default_save() -> bool {
 /// Used in message metadata to specify per-part behavior.
 pub type PartsMetadata = std::collections::HashMap<usize, PartMetadata>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
 pub struct Message {
     pub id: String,
     pub name: Option<String>,
     pub role: MessageRole,
+    #[schema(value_type = Vec<Object>)]
     pub parts: Vec<Part>,
     pub created_at: i64,
     /// The ID of the agent that generated this message (for Assistant messages)
@@ -374,7 +377,7 @@ impl TaskMessage {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum ToolCallStatus {
     #[default]
@@ -390,7 +393,7 @@ pub struct TaskEvent {
     pub created_at: i64,
     pub is_final: bool,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema, ToSchema)]
 pub struct AgentPlan {
     pub steps: Vec<PlanStep>,
     pub reasoning: Option<String>,
@@ -405,7 +408,7 @@ impl AgentPlan {
 }
 
 /// Plan step for execution
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct PlanStep {
     pub id: String,
@@ -414,18 +417,19 @@ pub struct PlanStep {
 }
 
 /// Action can be either a tool call or an LLM call
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 #[serde(untagged)]
 pub enum Action {
     ToolCalls { tool_calls: Vec<ToolCall> },
     Code { code: String, language: String },
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, ToSchema)]
 pub struct ToolResponse {
     pub tool_call_id: String,
     pub tool_name: String,
     /// Content as parts - automatically converts large content to Part::Artifact
+    #[schema(value_type = Vec<Object>)]
     pub parts: Vec<Part>,
     /// Metadata for parts (e.g., which parts to save)
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -525,7 +529,7 @@ impl ToolResponse {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Default, ToSchema)]
 pub struct Task {
     pub id: String,
     pub thread_id: String,
@@ -535,7 +539,7 @@ pub struct Task {
     pub updated_at: i64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, Default, ToSchema)]
 pub enum TaskStatus {
     #[default]
     Pending,
@@ -546,16 +550,17 @@ pub enum TaskStatus {
     Canceled,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct McpSession {
     /// The token for the MCP session.
     pub token: String,
     /// The expiry time of the session, if specified.
+    #[schema(value_type = Option<String>)]
     pub expiry: Option<SystemTime>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ToolCall {
     pub tool_call_id: String,
@@ -596,7 +601,7 @@ pub fn validate_parameters(
     Ok(())
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct Thread {
     pub id: String,
     pub title: String,
@@ -672,7 +677,7 @@ impl Thread {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct ThreadSummary {
     pub id: String,
     pub title: String,
@@ -705,7 +710,7 @@ pub struct ThreadSummary {
 
 // CreateThreadRequest removed - threads are now auto-created from first messages
 // Thread creation is handled internally when a message is sent with a context_id
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 pub struct CreateThreadRequest {
     pub agent_id: String,
     pub title: Option<String>,
@@ -719,15 +724,16 @@ pub struct CreateThreadRequest {
     pub channel_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateThreadRequest {
     pub title: Option<String>,
+    #[schema(value_type = Option<Object>)]
     pub metadata: Option<HashMap<String, serde_json::Value>>,
     pub attributes: Option<serde_json::Value>,
     pub user_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq, ToSchema)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum FileType {
     Bytes {

--- a/distri-types/src/dynamic_tool.rs
+++ b/distri-types/src/dynamic_tool.rs
@@ -1,9 +1,10 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// A dynamic tool factory definition. The `factory_type` determines
 /// how `config` is interpreted and what tool is created.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DynamicToolFactory {
     /// Name of the tool to create (e.g. "zippy_request")

--- a/distri-types/src/stores.rs
+++ b/distri-types/src/stores.rs
@@ -2,9 +2,11 @@ use crate::connections::{Connection, ConnectionStatus, ConnectionToken, NewConne
 use crate::{ScratchpadEntry, ToolAuthStore, ToolResponse};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::{collections::HashMap, sync::Arc};
+use utoipa::ToSchema;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -16,7 +18,7 @@ use crate::{
 // Redis and PostgreSQL stores moved to distri-stores crate
 
 /// Filter for listing threads
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct ThreadListFilter {
     /// Filter by agent ID
     pub agent_id: Option<String>,
@@ -36,7 +38,7 @@ pub struct ThreadListFilter {
 }
 
 /// Paginated response for thread listing
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct ThreadListResponse {
     pub threads: Vec<crate::ThreadSummary>,
     pub total: i64,
@@ -45,7 +47,7 @@ pub struct ThreadListResponse {
 }
 
 /// Agent usage information for sorting agents by thread count
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct AgentUsageInfo {
     pub agent_id: String,
     pub agent_name: String,
@@ -107,7 +109,7 @@ impl std::fmt::Debug for InitializedStores {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema, JsonSchema)]
 pub struct SessionSummary {
     pub session_id: String,
     pub keys: Vec<String>,
@@ -211,7 +213,7 @@ pub struct SessionMemory {
     pub important_facts: Vec<String>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
 }
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum FilterMessageType {
     Events,
@@ -219,7 +221,7 @@ pub enum FilterMessageType {
     Artifacts,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct MessageFilter {
     pub filter: Option<Vec<FilterMessageType>>,
     pub limit: Option<usize>,
@@ -384,7 +386,7 @@ pub trait ThreadStore: Send + Sync {
 }
 
 /// Home statistics for dashboard
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, JsonSchema)]
 pub struct HomeStats {
     pub total_agents: i64,
     pub total_threads: i64,
@@ -409,7 +411,7 @@ pub struct HomeStats {
 }
 
 /// A custom metric for display in the stats overview
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, JsonSchema)]
 pub struct CustomMetric {
     /// Display label (e.g., "Monthly Calls")
     pub label: String,
@@ -429,7 +431,7 @@ pub struct CustomMetric {
     pub raw_limit: Option<i64>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, JsonSchema)]
 pub struct MostActiveAgent {
     pub id: String,
     pub name: String,
@@ -437,7 +439,7 @@ pub struct MostActiveAgent {
 }
 
 /// Agent that was recently used (based on thread activity)
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, JsonSchema)]
 pub struct RecentlyUsedAgent {
     pub id: String,
     pub name: String,
@@ -445,7 +447,7 @@ pub struct RecentlyUsedAgent {
     pub last_used_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema, JsonSchema)]
 pub struct LatestThreadInfo {
     pub id: String,
     pub title: String,
@@ -455,7 +457,7 @@ pub struct LatestThreadInfo {
 }
 
 /// Agent statistics for display
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, ToSchema, JsonSchema)]
 pub struct AgentStatsInfo {
     pub thread_count: i64,
     pub sub_agent_usage_count: i64,
@@ -510,7 +512,7 @@ pub trait ScratchpadStore: Send + Sync + std::fmt::Debug {
 }
 
 /// Web crawl result data
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct CrawlResult {
     pub id: String,
     pub url: String,
@@ -564,7 +566,7 @@ pub trait CrawlStore: Send + Sync {
 // ========== Message Read & Voting Types ==========
 
 /// Vote type for message feedback
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, ToSchema, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum VoteType {
     Upvote,
@@ -572,7 +574,7 @@ pub enum VoteType {
 }
 
 /// Record of a message being read
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct MessageReadStatus {
     pub thread_id: String,
     pub message_id: String,
@@ -581,14 +583,14 @@ pub struct MessageReadStatus {
 }
 
 /// Request to mark a message as read
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct MarkMessageReadRequest {
     pub thread_id: String,
     pub message_id: String,
 }
 
 /// A vote on a message with optional feedback comment
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct MessageVote {
     pub id: String,
     pub thread_id: String,
@@ -602,7 +604,8 @@ pub struct MessageVote {
 }
 
 /// Request to vote on a message
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
+#[schema(example = json!({"vote_type": "up"}))]
 pub struct VoteMessageRequest {
     pub thread_id: String,
     pub message_id: String,
@@ -612,7 +615,7 @@ pub struct VoteMessageRequest {
 }
 
 /// Summary of votes for a message
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema, JsonSchema)]
 pub struct MessageVoteSummary {
     pub message_id: String,
     pub upvotes: i64,
@@ -646,7 +649,7 @@ pub trait ExternalToolCallsStore: Send + Sync + std::fmt::Debug {
 
 // ========== Prompt Template Store ==========
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct PromptTemplateRecord {
     pub id: String,
     pub name: String,
@@ -658,7 +661,8 @@ pub struct PromptTemplateRecord {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
+#[schema(example = json!({"name": "greeting", "content": "Hello {{name}}, welcome to {{service}}!", "description": "A greeting template"}))]
 pub struct NewPromptTemplate {
     pub name: String,
     pub template: String,
@@ -668,7 +672,7 @@ pub struct NewPromptTemplate {
     pub is_system: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UpdatePromptTemplate {
     pub name: String,
     pub template: String,
@@ -694,7 +698,7 @@ pub trait PromptTemplateStore: Send + Sync {
 
 // ========== Secret Store ==========
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct SecretRecord {
     pub id: String,
     pub key: String,
@@ -703,7 +707,8 @@ pub struct SecretRecord {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
+#[schema(example = json!({"key": "OPENAI_API_KEY", "value": "sk-..."}))]
 pub struct NewSecret {
     pub key: String,
     pub value: String,
@@ -720,7 +725,7 @@ pub trait SecretStore: Send + Sync {
 
 // ========== Provider Store ==========
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct CustomProviderConfig {
     pub id: String,
     pub name: String,
@@ -729,7 +734,7 @@ pub struct CustomProviderConfig {
     pub project_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct CustomModelEntry {
     pub provider: String,
     pub model: String,
@@ -743,7 +748,7 @@ fn default_completion() -> String {
 }
 
 /// A custom connection provider (OAuth integration) stored in workspace settings.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct ConnectionProviderConfig {
     /// Unique identifier (e.g., "linear", "figma", "custom_crm")
     pub id: String,
@@ -768,7 +773,7 @@ pub struct ConnectionProviderConfig {
 }
 
 /// Request payload for upserting a provider configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UpsertProviderRequest {
     pub provider_id: String,
     #[serde(default)]
@@ -786,7 +791,7 @@ pub struct UpsertProviderRequest {
 }
 
 /// Response after upserting a provider.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UpsertProviderResponse {
     pub provider_id: String,
     pub secrets_saved: usize,
@@ -809,7 +814,7 @@ pub trait ProviderStore: Send + Sync {
 
 /// How a skill is executed relative to the calling agent's context.
 /// Mirrors the `context` field in claude-code's prompt command spec.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, ToSchema, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum ContextExecutionType {
     /// Inject the full skill content into the current agent's context window.
@@ -849,7 +854,7 @@ pub const SKILL_DESCRIPTION_CAP: usize = 250;
 pub const DEFAULT_SKILL_MAX_TOKENS: u32 = 8000;
 
 /// Parsed frontmatter from a skill markdown file.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema, JsonSchema)]
 pub struct SkillFrontmatter {
     pub name: String,
     #[serde(default)]
@@ -919,14 +924,14 @@ pub fn format_skill_listing(skills: &[SkillFrontmatter], budget_tokens: usize) -
 }
 
 /// API response wrapper for skill list endpoints.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct SkillsListResponse {
     pub skills: Vec<SkillListItem>,
 }
 
 /// Lighter skill record for list endpoints — no content or scripts.
 /// Used by both distri-server (OSS) and distri-cloud.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct SkillListItem {
     pub id: String,
     #[serde(default)]
@@ -954,7 +959,7 @@ pub struct SkillListItem {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct SkillRecord {
     pub id: String,
     pub name: String,
@@ -975,7 +980,8 @@ pub struct SkillRecord {
     pub context: ContextExecutionType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
+#[schema(example = json!({"name": "my-skill", "content": "# My Skill\nA helpful utility skill", "description": "A utility skill", "tags": ["utility"], "is_public": false}))]
 pub struct NewSkill {
     pub name: String,
     pub description: Option<String>,
@@ -990,7 +996,7 @@ pub struct NewSkill {
     pub context: ContextExecutionType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UpdateSkill {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -1022,14 +1028,14 @@ pub trait SkillStore: Send + Sync {
 // ========== Workflow Store ==========
 
 /// API response wrapper for workflow list endpoints.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct WorkflowsListResponse {
     pub workflows: Vec<WorkflowListItem>,
     pub total: i64,
 }
 
 /// Lightweight workflow record for list endpoints — no definition payload.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct WorkflowListItem {
     pub id: String,
     pub name: String,
@@ -1058,7 +1064,7 @@ pub struct WorkflowListItem {
 /// Full workflow record with definition payload.
 /// `definition` is `serde_json::Value` to avoid crate dependency on distri-workflow.
 /// Deserialize to `WorkflowDefinition` on demand.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct WorkflowRecord {
     pub id: String,
     pub name: String,
@@ -1076,7 +1082,7 @@ pub struct WorkflowRecord {
 }
 
 /// Request to create a new workflow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct NewWorkflow {
     pub name: String,
     pub description: Option<String>,
@@ -1091,7 +1097,7 @@ pub struct NewWorkflow {
 }
 
 /// Partial update for a workflow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UpdateWorkflow {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -1101,7 +1107,7 @@ pub struct UpdateWorkflow {
 }
 
 /// Filter for listing workflows.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct WorkflowFilter {
     pub is_public: Option<bool>,
     pub is_template: Option<bool>,
@@ -1134,7 +1140,7 @@ pub trait WorkflowStore: Send + Sync {
 // ─── Usage Service ──────────────────────────────────────────────────────────
 
 /// Current usage snapshot for a workspace/user.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UsageSnapshot {
     pub day_tokens: i64,
     pub week_tokens: i64,
@@ -1142,7 +1148,7 @@ pub struct UsageSnapshot {
 }
 
 /// Configured token limits for a workspace.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema, JsonSchema)]
 pub struct UsageLimits {
     pub daily_tokens: Option<i64>,
     pub weekly_tokens: Option<i64>,

--- a/server/distri-server/Cargo.toml
+++ b/server/distri-server/Cargo.toml
@@ -55,6 +55,9 @@ browsr-client = { workspace = true }
 browsr-types = { workspace = true }
 
 schemars = { workspace = true }
+utoipa = { workspace = true }
+utoipa-actix-web = { workspace = true }
+utoipa-scalar = { workspace = true }
 async-openai = { workspace = true }
 reqwest = { workspace = true }
 bytes = "1.0"
@@ -68,3 +71,7 @@ static-files = "0.3"
 
 [dev-dependencies]
 tempfile = "3.12"
+actix-web = { workspace = true, features = ["macros"] }
+actix-rt = { workspace = true }
+reqwest = { workspace = true }
+uuid = { workspace = true }

--- a/server/distri-server/src/agent_server.rs
+++ b/server/distri-server/src/agent_server.rs
@@ -7,6 +7,8 @@ use actix_web::{web, App, HttpResponse, HttpServer, Result as ActixResult};
 use actix_web_static_files::ResourceFiles;
 use anyhow::Result;
 use distri_core::agent::AgentOrchestrator;
+use utoipa::OpenApi;
+use utoipa_scalar::Servable;
 
 use distri_types::configuration::ServerConfig;
 use serde_json::json;
@@ -121,6 +123,16 @@ impl DistriAgentServer {
                             async move { default_health_check(&service_name).await }
                         }
                     }),
+                )
+                .route(
+                    "/openapi.json",
+                    web::get().to(crate::openapi::serve_openapi),
+                )
+                .service(
+                    utoipa_scalar::Scalar::with_url(
+                        "/docs",
+                        crate::openapi::ServerApiDoc::openapi(),
+                    ),
                 )
                 .configure(|cfg| {
                     cfg.app_data(web::Data::new(executor))

--- a/server/distri-server/src/lib.rs
+++ b/server/distri-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent_server;
 pub mod auth_routes;
 pub mod context;
+pub mod openapi;
 pub mod routes;
 pub mod server;
 

--- a/server/distri-server/src/openapi.rs
+++ b/server/distri-server/src/openapi.rs
@@ -1,0 +1,141 @@
+//! OpenAPI specification for the Distri Server API.
+//!
+//! Generates a complete OpenAPI 3.1 spec from utoipa path annotations
+//! and ToSchema derives. Served at `/openapi.json` and browsable via
+//! Scalar UI at `/docs`.
+
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Distri Server API",
+        version = "0.3.7",
+        description = "Local/self-hosted Distri agent server. Provides agent management, \
+            thread/conversation history, tool execution, session storage, secrets, \
+            skills, workflows, and more.",
+        license(name = "MIT")
+    ),
+    servers(
+        (url = "http://localhost:8081", description = "Default local server")
+    ),
+    tags(
+        (name = "Agents", description = "Agent CRUD and execution"),
+        (name = "Threads", description = "Conversation threads and messages"),
+        (name = "Tools", description = "Tool listing and invocation"),
+        (name = "Sessions", description = "Key-value session storage"),
+        (name = "Secrets", description = "Secret/API key management"),
+        (name = "Skills", description = "Skill management"),
+        (name = "Workflows", description = "Workflow definitions"),
+        (name = "Providers", description = "LLM provider configuration"),
+        (name = "Models", description = "Available LLM models"),
+        (name = "Prompt Templates", description = "Reusable prompt templates"),
+        (name = "Artifacts", description = "Task artifact storage"),
+        (name = "Configuration", description = "Server configuration and device info"),
+        (name = "Health", description = "Health checks"),
+    ),
+    paths(
+        // Agents
+        crate::routes::list_agents,
+        crate::routes::get_agent_definition,
+        crate::routes::create_agent,
+        crate::routes::update_agent,
+        crate::routes::delete_agent,
+        crate::routes::validate_agent_handler,
+        crate::routes::get_agent_dag,
+        crate::routes::get_agent_schema,
+        // Threads
+        crate::routes::list_threads_handler,
+        crate::routes::list_agents_by_usage,
+        crate::routes::get_thread_handler,
+        crate::routes::update_thread_handler,
+        crate::routes::delete_thread_handler,
+        crate::routes::get_thread_messages,
+        // Message interactions
+        crate::routes::mark_message_read_handler,
+        crate::routes::get_message_read_status_handler,
+        crate::routes::get_thread_read_status_handler,
+        crate::routes::vote_message_handler,
+        crate::routes::remove_vote_handler,
+        crate::routes::get_message_vote_summary_handler,
+        crate::routes::get_message_votes_handler,
+        // Tasks
+        crate::routes::list_tasks,
+        // Tools
+        crate::routes::list_tools,
+        // Configuration
+        crate::routes::get_configuration,
+        crate::routes::get_device_info,
+        crate::routes::get_home_stats,
+        // Sessions
+        crate::routes::session::list_sessions,
+        crate::routes::session::get_all_values,
+        crate::routes::session::set_value,
+        crate::routes::session::get_value,
+        crate::routes::session::delete_value,
+        crate::routes::session::clear_session,
+        // Secrets
+        crate::routes::secrets::list_secrets,
+        crate::routes::secrets::create_secret,
+        crate::routes::secrets::list_provider_definitions,
+        crate::routes::secrets::list_configured,
+        crate::routes::secrets::get_secret,
+        crate::routes::secrets::update_secret,
+        crate::routes::secrets::delete_secret,
+        // Skills
+        crate::routes::skills::list_skills,
+        crate::routes::skills::create_skill,
+        crate::routes::skills::get_skill,
+        crate::routes::skills::update_skill,
+        crate::routes::skills::delete_skill,
+        // Workflows
+        crate::routes::workflows::list_workflows,
+        crate::routes::workflows::create_workflow,
+        crate::routes::workflows::get_workflow,
+        crate::routes::workflows::update_workflow,
+        crate::routes::workflows::delete_workflow,
+        // Providers
+        crate::routes::providers::upsert_provider,
+        crate::routes::providers::delete_provider,
+        crate::routes::providers::get_default_model,
+        // Models
+        crate::routes::models::list_models,
+        // Prompt Templates
+        crate::routes::prompt_templates::list_prompt_templates,
+        crate::routes::prompt_templates::create_prompt_template,
+        crate::routes::prompt_templates::get_prompt_template,
+        crate::routes::prompt_templates::update_prompt_template,
+        crate::routes::prompt_templates::delete_prompt_template,
+    ),
+    components(schemas(
+        // Route-level types
+        crate::routes::AgentWithStats,
+        crate::routes::ConfigurationMeta,
+        crate::routes::DeviceResponse,
+        crate::routes::DeviceMetadata,
+        crate::routes::DeviceStorageScope,
+        crate::routes::ToolListItem,
+        crate::routes::ToolSearchQuery,
+        // Session types
+        crate::routes::session::SetValueRequest,
+        crate::routes::session::GetValueResponse,
+        crate::routes::session::GetAllValuesResponse,
+        crate::routes::session::ListSessionsQuery,
+        crate::routes::session::SessionListItem,
+        // Secret types
+        crate::routes::secrets::SecretResponse,
+        crate::routes::secrets::ConfiguredField,
+        // Prompt template types
+        crate::routes::prompt_templates::SyncPromptTemplatesRequest,
+        crate::routes::prompt_templates::SyncPromptTemplatesResponse,
+    ))
+)]
+pub struct ServerApiDoc;
+
+/// Serve the generated OpenAPI JSON spec
+pub async fn serve_openapi() -> actix_web::HttpResponse {
+    let spec = ServerApiDoc::openapi().to_json().unwrap_or_default();
+    actix_web::HttpResponse::Ok()
+        .content_type("application/json")
+        .body(spec)
+}

--- a/server/distri-server/src/routes.rs
+++ b/server/distri-server/src/routes.rs
@@ -16,8 +16,10 @@ use distri_types::stores::{VoteMessageRequest, VoteType};
 use distri_types::StandardDefinition;
 use distri_types::{ExternalTool, InlineHookResponse, Message, ModelSettings};
 use futures_util::StreamExt;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use utoipa::ToSchema;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -28,17 +30,17 @@ use crate::agent_server::VerboseLog;
 use crate::auth_routes;
 use crate::context::UserContext;
 
-mod artifacts;
+pub mod artifacts;
 mod files;
 mod llm_helpers;
-mod models;
-mod prompt_templates;
+pub mod models;
+pub mod prompt_templates;
 pub mod providers;
-mod secrets;
-mod session;
-mod skills;
-mod tools;
-mod workflows;
+pub mod secrets;
+pub mod session;
+pub mod skills;
+pub mod tools;
+pub mod workflows;
 
 pub fn all(cfg: &mut web::ServiceConfig) {
     cfg.configure(distri);
@@ -133,14 +135,21 @@ pub fn distri(cfg: &mut web::ServiceConfig) {
 }
 
 /// Agent with stats response
-#[derive(Debug, Serialize)]
-struct AgentWithStats {
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgentWithStats {
     #[serde(flatten)]
+    #[schema(value_type = Object)]
     config: distri_types::configuration::AgentConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     stats: Option<distri_types::stores::AgentStatsInfo>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/agents",
+    tag = "Agents",
+    responses((status = 200, description = "List all agents with stats", body = Vec<AgentWithStats>))
+)]
 async fn list_agents(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     let (agents, _) = executor.stores.agent_store.list(None, None).await;
 
@@ -164,19 +173,26 @@ async fn list_agents(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpRespons
     HttpResponse::Ok().json(agents_with_stats)
 }
 
-#[derive(Debug, Serialize)]
-struct ConfigurationMeta {
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ConfigurationMeta {
+    #[schema(value_type = Object)]
     configuration: DistriServerConfig,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/configuration",
+    tag = "Configuration",
+    responses((status = 200, description = "Get server configuration", body = ConfigurationMeta))
+)]
 async fn get_configuration(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     // Use the orchestrator's in-memory configuration snapshot
     let cfg = executor.configuration.read().await.clone();
     HttpResponse::Ok().json(ConfigurationMeta { configuration: cfg })
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct DeviceMetadata {
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema, JsonSchema)]
+pub struct DeviceMetadata {
     #[serde(default = "new_device_id")]
     device_id: String,
     #[serde(default = "default_device_type")]
@@ -193,21 +209,27 @@ struct DeviceMetadata {
     updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Serialize)]
-struct DeviceResponse {
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
+pub struct DeviceResponse {
     #[serde(flatten)]
     device: DeviceMetadata,
     storage_path: String,
     storage_scope: DeviceStorageScope,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-enum DeviceStorageScope {
+pub enum DeviceStorageScope {
     Home,
     Workspace,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/device",
+    tag = "Configuration",
+    responses((status = 200, description = "Get device info", body = DeviceResponse))
+)]
 async fn get_device_info() -> HttpResponse {
     match load_device_profile().await {
         Ok(device) => HttpResponse::Ok().json(device),
@@ -359,15 +381,15 @@ fn utc_now() -> DateTime<Utc> {
     Utc::now()
 }
 
-#[derive(Debug, Serialize)]
-struct ToolListItem {
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
+pub struct ToolListItem {
     tool_name: String,
     description: String,
     input_schema: serde_json::Value,
 }
 
-#[derive(Debug, Deserialize)]
-struct ToolSearchQuery {
+#[derive(Debug, Deserialize, ToSchema, JsonSchema)]
+pub struct ToolSearchQuery {
     search: Option<String>,
 }
 
@@ -385,6 +407,12 @@ fn canonical_tool_name(tool: &Arc<dyn distri_core::tools::Tool>) -> String {
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/tools",
+    tag = "Tools",
+    responses((status = 200, description = "List available tools", body = Vec<ToolListItem>))
+)]
 async fn list_tools(
     query: web::Query<ToolSearchQuery>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -440,6 +468,13 @@ async fn build_workspace(_executor: web::Data<Arc<AgentOrchestrator>>) -> HttpRe
     HttpResponse::Ok().json(json!({ "status": "built" }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/agents/{id}",
+    tag = "Agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses((status = 200, description = "Get agent definition"))
+)]
 async fn get_agent_definition(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -513,6 +548,13 @@ struct AgentValidationResponse {
 }
 
 /// Validate an agent's configuration and return any warnings
+#[utoipa::path(
+    get,
+    path = "/v1/agents/{id}/validate",
+    tag = "Agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses((status = 200, description = "Validation result"))
+)]
 async fn validate_agent_handler(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -973,6 +1015,12 @@ struct ListThreadsQuery {
     filter: Option<serde_json::Value>, // Attributes filter
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads",
+    tag = "Threads",
+    responses((status = 200, description = "List threads"))
+)]
 async fn list_threads_handler(
     query: web::Query<ListThreadsQuery>,
     coordinator: web::Data<Arc<AgentOrchestrator>>,
@@ -1016,6 +1064,12 @@ async fn list_threads_handler(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads/agents",
+    tag = "Threads",
+    responses((status = 200, description = "List agents by usage"))
+)]
 async fn list_agents_by_usage(
     coordinator: web::Data<Arc<AgentOrchestrator>>,
     query: web::Query<std::collections::HashMap<String, String>>,
@@ -1031,6 +1085,13 @@ async fn list_agents_by_usage(
 
 // create_thread_handler removed - threads are now auto-created from first messages
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}",
+    tag = "Threads",
+    params(("thread_id" = String, Path, description = "Thread ID")),
+    responses((status = 200, description = "Get thread"))
+)]
 async fn get_thread_handler(
     path: web::Path<String>,
     coordinator: web::Data<Arc<AgentOrchestrator>>,
@@ -1047,6 +1108,13 @@ async fn get_thread_handler(
     }
 }
 
+#[utoipa::path(
+    put,
+    path = "/v1/threads/{thread_id}",
+    tag = "Threads",
+    params(("thread_id" = String, Path, description = "Thread ID")),
+    responses((status = 200, description = "Update thread"))
+)]
 async fn update_thread_handler(
     path: web::Path<String>,
     request: web::Json<UpdateThreadRequest>,
@@ -1064,6 +1132,13 @@ async fn update_thread_handler(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/threads/{thread_id}",
+    tag = "Threads",
+    params(("thread_id" = String, Path, description = "Thread ID")),
+    responses((status = 204, description = "Thread deleted"))
+)]
 async fn delete_thread_handler(
     path: web::Path<String>,
     coordinator: web::Data<Arc<AgentOrchestrator>>,
@@ -1079,6 +1154,16 @@ async fn delete_thread_handler(
 
 // ========== Message Read Status Handlers ==========
 
+#[utoipa::path(
+    post,
+    path = "/v1/threads/{thread_id}/messages/{message_id}/read",
+    tag = "Threads",
+    params(
+        ("thread_id" = String, Path, description = "Thread ID"),
+        ("message_id" = String, Path, description = "Message ID"),
+    ),
+    responses((status = 200, description = "Message marked as read"))
+)]
 async fn mark_message_read_handler(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1097,6 +1182,16 @@ async fn mark_message_read_handler(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}/messages/{message_id}/read",
+    tag = "Threads",
+    params(
+        ("thread_id" = String, Path, description = "Thread ID"),
+        ("message_id" = String, Path, description = "Message ID"),
+    ),
+    responses((status = 200, description = "Get message read status"))
+)]
 async fn get_message_read_status_handler(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1118,6 +1213,13 @@ async fn get_message_read_status_handler(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}/read-status",
+    tag = "Threads",
+    params(("thread_id" = String, Path, description = "Thread ID")),
+    responses((status = 200, description = "Get thread read status"))
+)]
 async fn get_thread_read_status_handler(
     path: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1138,12 +1240,22 @@ async fn get_thread_read_status_handler(
 
 // ========== Message Voting Handlers ==========
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 struct VoteRequest {
     vote_type: VoteType,
     comment: Option<String>,
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/threads/{thread_id}/messages/{message_id}/vote",
+    tag = "Threads",
+    params(
+        ("thread_id" = String, Path, description = "Thread ID"),
+        ("message_id" = String, Path, description = "Message ID"),
+    ),
+    responses((status = 200, description = "Vote on message"))
+)]
 async fn vote_message_handler(
     path: web::Path<(String, String)>,
     request: web::Json<VoteRequest>,
@@ -1179,6 +1291,16 @@ async fn vote_message_handler(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/threads/{thread_id}/messages/{message_id}/vote",
+    tag = "Threads",
+    params(
+        ("thread_id" = String, Path, description = "Thread ID"),
+        ("message_id" = String, Path, description = "Message ID"),
+    ),
+    responses((status = 204, description = "Vote removed"))
+)]
 async fn remove_vote_handler(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1197,6 +1319,16 @@ async fn remove_vote_handler(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}/messages/{message_id}/vote",
+    tag = "Threads",
+    params(
+        ("thread_id" = String, Path, description = "Thread ID"),
+        ("message_id" = String, Path, description = "Message ID"),
+    ),
+    responses((status = 200, description = "Get vote summary"))
+)]
 async fn get_message_vote_summary_handler(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1215,6 +1347,16 @@ async fn get_message_vote_summary_handler(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}/messages/{message_id}/votes",
+    tag = "Threads",
+    params(
+        ("thread_id" = String, Path, description = "Thread ID"),
+        ("message_id" = String, Path, description = "Message ID"),
+    ),
+    responses((status = 200, description = "Get message votes"))
+)]
 async fn get_message_votes_handler(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1242,6 +1384,12 @@ struct ListTasksQuery {
     offset: Option<u32>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/tasks",
+    tag = "Agents",
+    responses((status = 200, description = "List tasks"))
+)]
 async fn list_tasks(
     query: web::Query<ListTasksQuery>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1274,6 +1422,13 @@ async fn list_tasks(
 }
 
 // Thread messages endpoint
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}/messages",
+    tag = "Threads",
+    params(("thread_id" = String, Path, description = "Thread ID")),
+    responses((status = 200, description = "Get thread messages"))
+)]
 async fn get_thread_messages(
     path: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -1290,6 +1445,12 @@ async fn get_thread_messages(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/home/stats",
+    tag = "Configuration",
+    responses((status = 200, description = "Get home stats"))
+)]
 async fn get_home_stats(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     match executor.stores.thread_store.get_home_stats().await {
         Ok(stats) => HttpResponse::Ok().json(stats),
@@ -1302,6 +1463,13 @@ async fn get_home_stats(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResp
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/agents",
+    tag = "Agents",
+    request_body(content = String, content_type = "text/markdown", description = "Agent definition in markdown with TOML frontmatter"),
+    responses((status = 200, description = "Create a new agent"))
+)]
 async fn create_agent(
     req: actix_web::HttpRequest,
     body: web::Bytes,
@@ -1372,6 +1540,14 @@ enum UpdateAgentRequest {
     Full(StandardDefinition),
 }
 
+#[utoipa::path(
+    put,
+    path = "/v1/agents/{id}",
+    tag = "Agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    request_body(content = String, content_type = "text/markdown", description = "Agent definition in markdown with TOML frontmatter"),
+    responses((status = 200, description = "Update an agent"))
+)]
 async fn update_agent(
     id: web::Path<String>,
     req: actix_web::HttpRequest,
@@ -1477,6 +1653,13 @@ async fn proxy_request_handler(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/agents/{id}",
+    tag = "Agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses((status = 204, description = "Agent deleted"))
+)]
 async fn delete_agent(
     executor: web::Data<Arc<AgentOrchestrator>>,
     path: web::Path<String>,
@@ -1491,6 +1674,12 @@ async fn delete_agent(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/schema/agent",
+    tag = "Agents",
+    responses((status = 200, description = "Get agent JSON schema"))
+)]
 async fn get_agent_schema() -> HttpResponse {
     use schemars::schema_for;
     let schema = schema_for!(StandardDefinition);
@@ -1498,6 +1687,13 @@ async fn get_agent_schema() -> HttpResponse {
 }
 
 /// Get DAG representation for an agent
+#[utoipa::path(
+    get,
+    path = "/v1/agents/{id}/dag",
+    tag = "Agents",
+    params(("id" = String, Path, description = "Agent ID")),
+    responses((status = 200, description = "Get agent DAG"))
+)]
 async fn get_agent_dag(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,

--- a/server/distri-server/src/routes/models.rs
+++ b/server/distri-server/src/routes/models.rs
@@ -8,6 +8,14 @@ pub fn configure_model_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(web::resource("/models").route(web::get().to(list_models)));
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/models",
+    tag = "Models",
+    responses(
+        (status = 200, description = "List models grouped by provider")
+    )
+)]
 /// Returns all supported models grouped by provider, with configuration status.
 /// Each provider group includes `configured: bool` indicating whether the
 /// provider's required API key(s) are set in secrets or environment.

--- a/server/distri-server/src/routes/prompt_templates.rs
+++ b/server/distri-server/src/routes/prompt_templates.rs
@@ -1,18 +1,20 @@
 use actix_web::{web, HttpResponse};
 use distri_core::agent::AgentOrchestrator;
 use distri_types::stores::{NewPromptTemplate, UpdatePromptTemplate};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 /// Request to sync multiple templates at once
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema, JsonSchema)]
 pub struct SyncPromptTemplatesRequest {
     pub templates: Vec<NewPromptTemplate>,
 }
 
 /// Response from syncing templates
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
 pub struct SyncPromptTemplatesResponse {
     pub created: usize,
     pub updated: usize,
@@ -49,6 +51,15 @@ pub fn configure_prompt_template_routes(cfg: &mut web::ServiceConfig) {
     );
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/prompt-templates",
+    tag = "Prompt Templates",
+    responses(
+        (status = 200, description = "List prompt templates"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list_prompt_templates(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     let store = match &executor.stores.prompt_template_store {
         Some(s) => s,
@@ -64,6 +75,19 @@ async fn list_prompt_templates(executor: web::Data<Arc<AgentOrchestrator>>) -> H
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/prompt-templates/{id}",
+    tag = "Prompt Templates",
+    params(
+        ("id" = String, Path, description = "Prompt template ID"),
+    ),
+    responses(
+        (status = 200, description = "Prompt template retrieved"),
+        (status = 404, description = "Prompt template not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_prompt_template(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -83,6 +107,16 @@ async fn get_prompt_template(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/prompt-templates",
+    tag = "Prompt Templates",
+    request_body = NewPromptTemplate,
+    responses(
+        (status = 200, description = "Prompt template created"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create_prompt_template(
     executor: web::Data<Arc<AgentOrchestrator>>,
     payload: web::Json<NewPromptTemplate>,
@@ -101,6 +135,19 @@ async fn create_prompt_template(
     }
 }
 
+#[utoipa::path(
+    put,
+    path = "/v1/prompt-templates/{id}",
+    tag = "Prompt Templates",
+    params(
+        ("id" = String, Path, description = "Prompt template ID"),
+    ),
+    request_body = UpdatePromptTemplate,
+    responses(
+        (status = 200, description = "Prompt template updated"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update_prompt_template(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -120,6 +167,18 @@ async fn update_prompt_template(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/prompt-templates/{id}",
+    tag = "Prompt Templates",
+    params(
+        ("id" = String, Path, description = "Prompt template ID"),
+    ),
+    responses(
+        (status = 204, description = "Prompt template deleted"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_prompt_template(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,

--- a/server/distri-server/src/routes/providers.rs
+++ b/server/distri-server/src/routes/providers.rs
@@ -11,6 +11,17 @@ pub fn configure_provider_routes(cfg: &mut web::ServiceConfig) {
         );
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/providers",
+    tag = "Providers",
+    request_body = UpsertProviderRequest,
+    responses(
+        (status = 200, description = "Provider upserted"),
+        (status = 400, description = "Bad request"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn upsert_provider(
     store: web::Data<Arc<dyn ProviderStore>>,
     payload: web::Json<UpsertProviderRequest>,
@@ -32,6 +43,18 @@ async fn upsert_provider(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/providers/{provider_id}",
+    tag = "Providers",
+    params(
+        ("provider_id" = String, Path, description = "Provider ID"),
+    ),
+    responses(
+        (status = 200, description = "Provider deleted"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_provider(
     store: web::Data<Arc<dyn ProviderStore>>,
     path: web::Path<String>,
@@ -46,6 +69,15 @@ async fn delete_provider(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/providers/default-model",
+    tag = "Providers",
+    responses(
+        (status = 200, description = "Default model retrieved"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_default_model(store: web::Data<Arc<dyn ProviderStore>>) -> HttpResponse {
     match store.get_default_model().await {
         Ok(dm) => HttpResponse::Ok().json(json!({"default_model": dm})),

--- a/server/distri-server/src/routes/secrets.rs
+++ b/server/distri-server/src/routes/secrets.rs
@@ -2,10 +2,12 @@ use actix_web::{web, HttpResponse};
 use distri_core::agent::AgentOrchestrator;
 use distri_types::stores::NewSecret;
 use distri_types::ModelProvider;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashSet;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 pub fn configure_secret_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
@@ -23,6 +25,14 @@ pub fn configure_secret_routes(cfg: &mut web::ServiceConfig) {
     );
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/secrets/providers",
+    tag = "Secrets",
+    responses(
+        (status = 200, description = "List provider definitions")
+    )
+)]
 /// Returns the list of supported providers and their required secret keys.
 /// This allows the frontend to dynamically display the correct options.
 async fn list_provider_definitions() -> HttpResponse {
@@ -31,12 +41,12 @@ async fn list_provider_definitions() -> HttpResponse {
 }
 
 /// A secret as returned to the frontend — values are always masked.
-#[derive(Serialize)]
-struct SecretResponse {
-    id: String,
-    key: String,
-    masked_value: String,
-    updated_at: chrono::DateTime<chrono::Utc>,
+#[derive(Serialize, ToSchema, JsonSchema)]
+pub struct SecretResponse {
+    pub id: String,
+    pub key: String,
+    pub masked_value: String,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// Build the set of sensitive key names from provider definitions.
@@ -52,16 +62,25 @@ fn sensitive_keys() -> HashSet<String> {
 /// Returns which provider keys are configured. For non-sensitive keys (URLs, project IDs)
 /// returns the actual value. For sensitive keys (API keys) returns only `is_set: true`.
 /// The frontend should use this instead of list_secrets for the settings page.
-#[derive(Serialize)]
-struct ConfiguredField {
-    key: String,
-    is_set: bool,
+#[derive(Serialize, ToSchema, JsonSchema)]
+pub struct ConfiguredField {
+    pub key: String,
+    pub is_set: bool,
     /// Only populated for non-sensitive fields
     #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<String>,
-    sensitive: bool,
+    pub value: Option<String>,
+    pub sensitive: bool,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/secrets/configured",
+    tag = "Secrets",
+    responses(
+        (status = 200, description = "List configured secrets", body = Vec<ConfiguredField>),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list_configured(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     let store = match &executor.stores.secret_store {
         Some(s) => s,
@@ -93,6 +112,15 @@ async fn list_configured(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpRes
     HttpResponse::Ok().json(fields)
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/secrets",
+    tag = "Secrets",
+    responses(
+        (status = 200, description = "List secrets", body = Vec<SecretResponse>),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list_secrets(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     let store = match &executor.stores.secret_store {
         Some(s) => s,
@@ -131,6 +159,19 @@ async fn list_secrets(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpRespon
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/secrets/{key}",
+    tag = "Secrets",
+    params(
+        ("key" = String, Path, description = "Secret key"),
+    ),
+    responses(
+        (status = 200, description = "Secret retrieved"),
+        (status = 404, description = "Secret not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_secret(
     key: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -150,6 +191,16 @@ async fn get_secret(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/secrets",
+    tag = "Secrets",
+    request_body = NewSecret,
+    responses(
+        (status = 200, description = "Secret created"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create_secret(
     executor: web::Data<Arc<AgentOrchestrator>>,
     payload: web::Json<NewSecret>,
@@ -168,11 +219,24 @@ async fn create_secret(
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, ToSchema, JsonSchema)]
 struct UpdateSecretPayload {
     value: String,
 }
 
+#[utoipa::path(
+    put,
+    path = "/v1/secrets/{key}",
+    tag = "Secrets",
+    params(
+        ("key" = String, Path, description = "Secret key"),
+    ),
+    request_body = UpdateSecretPayload,
+    responses(
+        (status = 200, description = "Secret updated"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update_secret(
     key: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -192,6 +256,18 @@ async fn update_secret(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/secrets/{key}",
+    tag = "Secrets",
+    params(
+        ("key" = String, Path, description = "Secret key"),
+    ),
+    responses(
+        (status = 204, description = "Secret deleted"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_secret(
     key: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,

--- a/server/distri-server/src/routes/session.rs
+++ b/server/distri-server/src/routes/session.rs
@@ -6,10 +6,13 @@ use actix_web::{web, HttpRequest, HttpResponse};
 use chrono::{DateTime, Utc};
 use distri_core::agent::AgentOrchestrator;
 use flate2::read::GzDecoder;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use utoipa::ToSchema;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema, JsonSchema)]
+#[schema(example = json!({"key": "user_preference", "value": {"theme": "dark"}}))]
 pub struct SetValueRequest {
     pub key: String,
     pub value: Value,
@@ -17,12 +20,12 @@ pub struct SetValueRequest {
     pub expiry: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
 pub struct GetValueResponse {
     pub value: Option<Value>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
 pub struct GetAllValuesResponse {
     pub values: HashMap<String, Value>,
 }
@@ -42,7 +45,7 @@ pub fn configure_session_routes(cfg: &mut web::ServiceConfig) {
         .service(web::resource("/{session_id}").route(web::delete().to(clear_session)));
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema, JsonSchema)]
 pub struct ListSessionsQuery {
     pub thread_id: Option<String>,
     pub task_id: Option<String>,
@@ -50,7 +53,7 @@ pub struct ListSessionsQuery {
     pub offset: Option<usize>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema, JsonSchema)]
 pub struct SessionListItem {
     pub session_id: String,
     pub thread_id: String,
@@ -60,6 +63,21 @@ pub struct SessionListItem {
     pub task_ids: Vec<String>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/sessions",
+    tag = "Sessions",
+    params(
+        ("thread_id" = Option<String>, Query, description = "Filter by thread ID"),
+        ("task_id" = Option<String>, Query, description = "Filter by task ID"),
+        ("limit" = Option<usize>, Query, description = "Maximum number of sessions to return"),
+        ("offset" = Option<usize>, Query, description = "Offset for pagination"),
+    ),
+    responses(
+        (status = 200, description = "List sessions", body = Vec<SessionListItem>),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list_sessions(
     query: web::Query<ListSessionsQuery>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -109,6 +127,19 @@ async fn list_sessions(
     HttpResponse::Ok().json(items)
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/sessions/{session_id}/values",
+    tag = "Sessions",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+    ),
+    request_body = SetValueRequest,
+    responses(
+        (status = 204, description = "Value set successfully"),
+        (status = 400, description = "Bad request")
+    )
+)]
 /// Set a session value. Supports gzip-compressed requests for large payloads.
 async fn set_value(
     req: HttpRequest,
@@ -181,6 +212,19 @@ async fn set_value(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/values/{key}",
+    tag = "Sessions",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("key" = String, Path, description = "Value key"),
+    ),
+    responses(
+        (status = 200, description = "Value retrieved", body = GetValueResponse),
+        (status = 400, description = "Bad request")
+    )
+)]
 async fn get_value(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -199,6 +243,18 @@ async fn get_value(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/sessions/{session_id}/values",
+    tag = "Sessions",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+    ),
+    responses(
+        (status = 200, description = "All values retrieved", body = GetAllValuesResponse),
+        (status = 400, description = "Bad request")
+    )
+)]
 async fn get_all_values(
     path: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -217,6 +273,19 @@ async fn get_all_values(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/sessions/{session_id}/values/{key}",
+    tag = "Sessions",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+        ("key" = String, Path, description = "Value key"),
+    ),
+    responses(
+        (status = 204, description = "Value deleted"),
+        (status = 400, description = "Bad request")
+    )
+)]
 async fn delete_value(
     path: web::Path<(String, String)>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -235,6 +304,18 @@ async fn delete_value(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/sessions/{session_id}",
+    tag = "Sessions",
+    params(
+        ("session_id" = String, Path, description = "Session ID"),
+    ),
+    responses(
+        (status = 204, description = "Session cleared"),
+        (status = 400, description = "Bad request")
+    )
+)]
 async fn clear_session(
     path: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,

--- a/server/distri-server/src/routes/skills.rs
+++ b/server/distri-server/src/routes/skills.rs
@@ -18,6 +18,15 @@ pub fn configure_skill_routes(cfg: &mut web::ServiceConfig) {
     );
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/skills",
+    tag = "Skills",
+    responses(
+        (status = 200, description = "List skills"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list_skills(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpResponse {
     let store = match &executor.stores.skill_store {
         Some(s) => s,
@@ -57,6 +66,19 @@ async fn list_skills(executor: web::Data<Arc<AgentOrchestrator>>) -> HttpRespons
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/skills/{id}",
+    tag = "Skills",
+    params(
+        ("id" = String, Path, description = "Skill ID"),
+    ),
+    responses(
+        (status = 200, description = "Skill retrieved"),
+        (status = 404, description = "Skill not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_skill(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -76,6 +98,16 @@ async fn get_skill(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/skills",
+    tag = "Skills",
+    request_body = NewSkill,
+    responses(
+        (status = 200, description = "Skill created"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create_skill(
     executor: web::Data<Arc<AgentOrchestrator>>,
     payload: web::Json<NewSkill>,
@@ -94,6 +126,19 @@ async fn create_skill(
     }
 }
 
+#[utoipa::path(
+    put,
+    path = "/v1/skills/{id}",
+    tag = "Skills",
+    params(
+        ("id" = String, Path, description = "Skill ID"),
+    ),
+    request_body = UpdateSkill,
+    responses(
+        (status = 200, description = "Skill updated"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update_skill(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -113,6 +158,18 @@ async fn update_skill(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/skills/{id}",
+    tag = "Skills",
+    params(
+        ("id" = String, Path, description = "Skill ID"),
+    ),
+    responses(
+        (status = 204, description = "Skill deleted"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_skill(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,

--- a/server/distri-server/src/routes/workflows.rs
+++ b/server/distri-server/src/routes/workflows.rs
@@ -1,9 +1,11 @@
 use actix_web::{web, HttpResponse};
 use distri_core::agent::AgentOrchestrator;
 use distri_types::stores::{NewWorkflow, UpdateWorkflow, WorkflowFilter};
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 pub fn configure_workflow_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
@@ -19,14 +21,29 @@ pub fn configure_workflow_routes(cfg: &mut web::ServiceConfig) {
     );
 }
 
-#[derive(Debug, Deserialize)]
-struct ListWorkflowsQuery {
+#[derive(Debug, Deserialize, ToSchema, JsonSchema)]
+pub struct ListWorkflowsQuery {
     is_template: Option<bool>,
     search: Option<String>,
     limit: Option<i64>,
     offset: Option<i64>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/workflows",
+    tag = "Workflows",
+    params(
+        ("is_template" = Option<bool>, Query, description = "Filter by template status"),
+        ("search" = Option<String>, Query, description = "Search term"),
+        ("limit" = Option<i64>, Query, description = "Maximum number of workflows to return"),
+        ("offset" = Option<i64>, Query, description = "Offset for pagination"),
+    ),
+    responses(
+        (status = 200, description = "List workflows"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list_workflows(
     executor: web::Data<Arc<AgentOrchestrator>>,
     query: web::Query<ListWorkflowsQuery>,
@@ -92,6 +109,19 @@ async fn list_workflows(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/workflows/{id}",
+    tag = "Workflows",
+    params(
+        ("id" = String, Path, description = "Workflow ID"),
+    ),
+    responses(
+        (status = 200, description = "Workflow retrieved"),
+        (status = 404, description = "Workflow not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_workflow(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -111,6 +141,16 @@ async fn get_workflow(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/v1/workflows",
+    tag = "Workflows",
+    request_body = NewWorkflow,
+    responses(
+        (status = 200, description = "Workflow created"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create_workflow(
     executor: web::Data<Arc<AgentOrchestrator>>,
     payload: web::Json<NewWorkflow>,
@@ -129,6 +169,19 @@ async fn create_workflow(
     }
 }
 
+#[utoipa::path(
+    put,
+    path = "/v1/workflows/{id}",
+    tag = "Workflows",
+    params(
+        ("id" = String, Path, description = "Workflow ID"),
+    ),
+    request_body = UpdateWorkflow,
+    responses(
+        (status = 200, description = "Workflow updated"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update_workflow(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,
@@ -148,6 +201,18 @@ async fn update_workflow(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/v1/workflows/{id}",
+    tag = "Workflows",
+    params(
+        ("id" = String, Path, description = "Workflow ID"),
+    ),
+    responses(
+        (status = 204, description = "Workflow deleted"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_workflow(
     id: web::Path<String>,
     executor: web::Data<Arc<AgentOrchestrator>>,

--- a/server/distri-server/tests/smoke.rs
+++ b/server/distri-server/tests/smoke.rs
@@ -1,0 +1,132 @@
+//! Smoke test: verify every route group returns something other than 500.
+//!
+//! Sends one unauthenticated request to a representative endpoint from each
+//! handler module. Unauthenticated requests should return 200, 401, or 404 —
+//! NOT 500 ("app_data not configured"). A 500 here means a handler is pulling
+//! `web::Data<T>` that was never registered with `.app_data()`.
+
+use actix_web::{middleware::Logger, web, App};
+use distri_core::AgentOrchestratorBuilder;
+use distri_types::configuration::{
+    DbConnectionConfig, MetadataStoreConfig, ServerConfig, StoreConfig,
+};
+use reqwest::{Client, Method};
+use std::sync::Arc;
+
+/// (method, path) pairs — one per handler group
+const SMOKE_ROUTES: &[(&str, &str)] = &[
+    // Health
+    ("GET", "/health"),
+    // Agents
+    ("GET", "/v1/agents"),
+    // Threads
+    ("GET", "/v1/threads"),
+    // Tools
+    ("GET", "/v1/tools"),
+    // Tasks
+    ("GET", "/v1/tasks"),
+    // Sessions
+    ("GET", "/v1/sessions"),
+    // Secrets
+    ("GET", "/v1/secrets"),
+    ("GET", "/v1/secrets/providers"),
+    ("GET", "/v1/secrets/configured"),
+    // Skills
+    ("GET", "/v1/skills"),
+    // Workflows
+    ("GET", "/v1/workflows"),
+    // Configuration
+    ("GET", "/v1/configuration"),
+    ("GET", "/v1/device"),
+    ("GET", "/v1/home/stats"),
+    // Models
+    ("GET", "/v1/models"),
+    // Prompt templates
+    ("GET", "/v1/prompt-templates"),
+    // Agent schema
+    ("GET", "/v1/schema/agent"),
+    // OpenAPI spec
+    ("GET", "/openapi.json"),
+];
+
+fn test_store_config() -> StoreConfig {
+    let db_name = uuid::Uuid::new_v4();
+    let db_url = format!("file:{}?mode=memory&cache=shared", db_name);
+    StoreConfig {
+        metadata: MetadataStoreConfig {
+            db_config: Some(DbConnectionConfig {
+                database_url: db_url,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn smoke_all_route_groups_have_app_data() {
+    // Build an in-memory orchestrator (SQLite)
+    let orchestrator = Arc::new(
+        AgentOrchestratorBuilder::default()
+            .with_store_config(test_store_config())
+            .build()
+            .await
+            .expect("failed to build test orchestrator"),
+    );
+
+    let server_config = ServerConfig::default();
+    let verbose = Some(distri_server::agent_server::VerboseLog(false));
+
+    let server = actix_web::test::start(move || {
+        let executor = orchestrator.clone();
+        App::new()
+            .wrap(Logger::default())
+            .app_data(web::Data::new(server_config.clone()))
+            .route(
+                "/health",
+                web::get().to(|| async {
+                    actix_web::HttpResponse::Ok().json(serde_json::json!({"status": "ok"}))
+                }),
+            )
+            .route(
+                "/openapi.json",
+                web::get().to(distri_server::openapi::serve_openapi),
+            )
+            .configure(|cfg| {
+                cfg.app_data(web::Data::new(executor))
+                    .app_data(web::Data::new(verbose.clone()))
+                    .configure(|cfg| {
+                        cfg.service(
+                            web::scope("/v1").configure(distri_server::routes::distri),
+                        );
+                    });
+            })
+    });
+
+    let client = Client::new();
+    let base = server.url("");
+
+    for (method, path) in SMOKE_ROUTES {
+        let method = match *method {
+            "GET" => Method::GET,
+            "POST" => Method::POST,
+            _ => unreachable!(),
+        };
+
+        let url = format!("{}{}", base.trim_end_matches('/'), path);
+        let resp = client
+            .request(method.clone(), &url)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("request failed for {method} {path}: {e}"));
+
+        let status = resp.status();
+        assert_ne!(
+            status.as_u16(),
+            500,
+            "{method} {path} returned 500 — likely missing app_data registration. Body: {}",
+            resp.text().await.unwrap_or_default()
+        );
+    }
+}

--- a/server/distri-server/tests/test_openapi_spec.rs
+++ b/server/distri-server/tests/test_openapi_spec.rs
@@ -1,0 +1,17 @@
+//! Verify the OpenAPI spec generates valid JSON.
+
+use utoipa::OpenApi;
+
+#[test]
+fn generate_openapi_spec_is_valid_json() {
+    let doc = distri_server::openapi::ServerApiDoc::openapi();
+    let json = doc
+        .to_json()
+        .expect("OpenAPI spec must serialize to JSON");
+    // Validate it parses back
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json).expect("OpenAPI JSON must parse");
+    // Must have paths and info
+    assert!(parsed.get("info").is_some(), "spec must have info section");
+    assert!(parsed.get("paths").is_some(), "spec must have paths section");
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive OpenAPI 3.1 specification generation and documentation for the Distri Server API, along with smoke tests to ensure all route handlers have proper dependency injection configured.

## Key Changes

### OpenAPI Documentation
- **New `openapi.rs` module**: Generates complete OpenAPI spec using `utoipa` with:
  - API metadata (title, version, description, license)
  - 12 tag categories (Agents, Threads, Tools, Sessions, Secrets, Skills, Workflows, Providers, Models, Prompt Templates, Artifacts, Configuration, Health)
  - All 60+ endpoint paths with proper HTTP methods, parameters, and response schemas
  - Scalar UI integration for interactive API documentation at `/docs`
  - Served at `/openapi.json` endpoint

### Route Annotations
- Added `#[utoipa::path(...)]` macros to 40+ handler functions with:
  - HTTP method and path specification
  - Tag categorization for grouping
  - Parameter documentation (path, query, request body)
  - Response status codes and descriptions
- Made route modules public (`pub mod`) to expose handlers for OpenAPI registration

### Schema Derivations
- Added `ToSchema` and `JsonSchema` derives to 50+ types across:
  - `routes.rs`: `AgentWithStats`, `ConfigurationMeta`, `DeviceResponse`, `DeviceMetadata`, `DeviceStorageScope`, `ToolListItem`, `ToolSearchQuery`, `VoteRequest`
  - `routes/session.rs`: `SetValueRequest`, `GetValueResponse`, `GetAllValuesResponse`, `ListSessionsQuery`, `SessionListItem`
  - `routes/secrets.rs`: `SecretResponse`, `ConfiguredField`
  - `routes/workflows.rs`, `routes/skills.rs`, `routes/prompt_templates.rs`: Query and request types
  - `distri-types`: Core types like `TokenUsage`, `ExternalTool`, `ToolDefinition`, `MessageRole`, `AdditionalPartsInstruction`, `ThreadListFilter`, `ThreadListResponse`, `AgentUsageInfo`, `SessionSummary`, `HomeStats`, `CustomMetric`, and connection/configuration types

### Testing
- **New `smoke.rs` test**: Validates that all 18 route groups have proper `web::Data` registrations:
  - Tests one representative endpoint per handler module
  - Ensures no 500 errors from missing `app_data()` configuration
  - Uses in-memory SQLite for fast test execution
- **New `test_openapi_spec.rs` test**: Verifies OpenAPI spec generates valid JSON and contains required sections

### Dependencies
- Added `utoipa` (5.x) with `actix_extras` and `chrono` features
- Added `utoipa-actix-web` for Actix-web integration
- Added `utoipa-scalar` for interactive API documentation UI

### Integration
- Updated `agent_server.rs` to serve OpenAPI spec and Scalar UI
- Made route modules public to allow OpenAPI macro access
- Updated `lib.rs` to export new `openapi` module

## Implementation Details
- OpenAPI spec uses `#[openapi(...)]` macro with comprehensive metadata and all paths/schemas
- Route handlers use `#[utoipa::path(...)]` for declarative documentation
- Schema types use `#[schema(...)]` attributes for custom type hints (e.g., `value_type = Object`)
- Smoke tests use `actix_web::test::start()` for isolated server testing
- All changes are backward compatible; no breaking changes to existing APIs

https://claude.ai/code/session_01CeK7hSt75KF2Gaqz7wLUb7