### PR TITLE
Add support for entry point selection via input parameter

### DIFF
--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -192,8 +192,18 @@ impl Distri {
     }
 
     pub async fn register_agent(&self, definition: &StandardDefinition) -> Result<(), ClientError> {
+        let config =
+            distri_types::configuration::AgentConfig::StandardAgent(definition.clone());
+        self.register_agent_config(&config).await
+    }
+
+    /// Register any agent type (standard or workflow) from a typed `AgentConfig`.
+    pub async fn register_agent_config(
+        &self,
+        config: &distri_types::configuration::AgentConfig,
+    ) -> Result<(), ClientError> {
         let create_url = format!("{}/agents", self.base_url);
-        let resp = self.http.post(&create_url).json(definition).send().await?;
+        let resp = self.http.post(&create_url).json(config).send().await?;
         if resp.status().is_success() {
             return Ok(());
         }

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -14,7 +14,23 @@ use crate::{
 use async_trait::async_trait;
 use distri_types::configuration::WorkflowAgentDefinition;
 use distri_workflow::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+/// Typed input envelope for workflow agent invocation.
+///
+/// Workflow-control fields (entry_point) are parsed explicitly;
+/// everything else is forwarded as the workflow's user input via `#[serde(flatten)]`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkflowInput {
+    /// Optional entry point ID to start the workflow from a specific step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry_point: Option<String>,
+
+    /// All remaining fields are forwarded as workflow user input.
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
 
 /// A workflow-based agent that executes a workflow DAG.
 #[derive(Clone, Debug)]
@@ -389,31 +405,31 @@ impl WorkflowAgent {
                 AgentError::Execution(format!("Invalid workflow definition: {}", e))
             })?;
 
-        // Extract input from message (first text part as JSON, or empty)
-        let input = message
+        // Parse typed input from message (first text part as JSON, or defaults)
+        let workflow_input: WorkflowInput = message
             .parts
             .iter()
             .find_map(|p| {
                 if let distri_types::Part::Text(text) = p {
-                    serde_json::from_str::<serde_json::Value>(text).ok()
+                    serde_json::from_str::<WorkflowInput>(text).ok()
                 } else {
                     None
                 }
             })
-            .unwrap_or(serde_json::json!({}));
+            .unwrap_or_default();
 
         // Save user message to thread (like StandardAgent does)
         context.save_message(&message).await;
 
-        // Validate and merge input
+        // Validate and merge the user data (everything except workflow control fields)
         workflow = workflow
-            .with_input(input.clone())
+            .with_input(workflow_input.data)
             .map_err(|e| AgentError::Validation(e))?;
 
-        // Apply entry point if specified in input (e.g. {"_entry_point": "grade_only"})
-        if let Some(entry_id) = input.get("_entry_point").and_then(|v| v.as_str()) {
+        // Apply entry point if specified
+        if let Some(entry_id) = workflow_input.entry_point {
             workflow = workflow
-                .apply_entry_point(entry_id)
+                .apply_entry_point(&entry_id)
                 .map_err(|e| AgentError::Validation(e))?;
         }
 

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -410,6 +410,13 @@ impl WorkflowAgent {
             .with_input(input.clone())
             .map_err(|e| AgentError::Validation(e))?;
 
+        // Apply entry point if specified in input (e.g. {"_entry_point": "grade_only"})
+        if let Some(entry_id) = input.get("_entry_point").and_then(|v| v.as_str()) {
+            workflow = workflow
+                .apply_entry_point(entry_id)
+                .map_err(|e| AgentError::Validation(e))?;
+        }
+
         // Populate env namespace from executor context env vars
         if let Some(ctx_obj) = workflow.context.as_object_mut() {
             let env = ctx_obj


### PR DESCRIPTION
## Summary
Added support for specifying a workflow entry point through an input parameter, allowing callers to dynamically select which entry point to use when executing a workflow.

## Key Changes
- Added logic to check for an `_entry_point` parameter in the workflow input
- If the parameter is present, the workflow's `apply_entry_point()` method is called with the specified entry point ID
- Validation errors from entry point application are properly propagated as `AgentError::Validation`

## Implementation Details
- The entry point parameter is extracted using `input.get("_entry_point").and_then(|v| v.as_str())` to safely handle optional string values
- The feature integrates seamlessly into the existing workflow initialization flow, applied after input validation but before environment namespace population
- This enables use cases like conditional workflow execution (e.g., `{"_entry_point": "grade_only"}`) without requiring separate workflow definitions

https://claude.ai/code/session_014qNg3e8bgDXFLwFi555xS1