### PR TITLE
feat: CLI named profiles for credential management

### DIFF
--- a/distri-a2a/src/a2a_types.rs
+++ b/distri-a2a/src/a2a_types.rs
@@ -124,7 +124,7 @@ pub struct AgentSkill {
 pub enum SecurityScheme {
     ApiKey(APIKeySecurityScheme),
     Http(HTTPAuthSecurityScheme),
-    Oauth2(OAuth2SecurityScheme),
+    Oauth2(Box<OAuth2SecurityScheme>),
     OpenIdConnect(OpenIdConnectSecurityScheme),
 }
 

--- a/distri-cli/src/commands.rs
+++ b/distri-cli/src/commands.rs
@@ -41,7 +41,10 @@ pub fn handle_profile_command(command: ProfileCommands) -> Result<()> {
                     .map(mask_api_key)
                     .unwrap_or_else(|| "(none)".to_string());
                 let ws_str = values.workspace_id.as_deref().unwrap_or("(none)");
-                let url_str = values.api_url.as_deref().unwrap_or("https://api.distri.dev/v1");
+                let url_str = values
+                    .api_url
+                    .as_deref()
+                    .unwrap_or("https://api.distri.dev/v1");
                 println!(
                     "{} {:<12}  api_key={:<20}  workspace={:<36}  url={}",
                     marker, name, key_str, ws_str, url_str

--- a/distri-cli/src/commands.rs
+++ b/distri-cli/src/commands.rs
@@ -6,25 +6,13 @@ use anyhow::{Context, Result};
 use distri::{CreateSkillRequest, Distri};
 use tokio::fs;
 
-use crate::config::set_client_config_value;
 use crate::{
-    ConfigCommands, ConnectionsCommands, PromptsCommands, SecretsCommands, SkillsCommands,
+    ConnectionsCommands, ProfileCommands, PromptsCommands, SecretsCommands, SkillsCommands,
     WorkflowCommands, COLOR_BRIGHT_GREEN, COLOR_GRAY, COLOR_RESET,
 };
 
-pub fn handle_config_command(command: ConfigCommands) -> Result<()> {
-    match command {
-        ConfigCommands::Set { key, value } => {
-            let raw_value = value
-                .into_iter()
-                .filter(|part| part != "=")
-                .collect::<Vec<_>>()
-                .join(" ");
-            let path = set_client_config_value(&key, &raw_value)?;
-            println!("Updated {} in {}", key, path.display());
-        }
-    }
-    Ok(())
+pub fn handle_profile_command(_command: ProfileCommands) -> Result<()> {
+    anyhow::bail!("Profile command not yet implemented (Task 4)")
 }
 
 pub async fn handle_prompts_command(client: &Distri, command: PromptsCommands) -> Result<()> {

--- a/distri-cli/src/commands.rs
+++ b/distri-cli/src/commands.rs
@@ -7,12 +7,162 @@ use distri::{CreateSkillRequest, Distri};
 use tokio::fs;
 
 use crate::{
-    ConnectionsCommands, ProfileCommands, PromptsCommands, SecretsCommands, SkillsCommands,
-    WorkflowCommands, COLOR_BRIGHT_GREEN, COLOR_GRAY, COLOR_RESET,
+    ConnectionsCommands, ProfileCommands, ProfileConfigCommands, PromptsCommands, SecretsCommands,
+    SkillsCommands, WorkflowCommands, COLOR_BRIGHT_GREEN, COLOR_GRAY, COLOR_RESET,
 };
 
-pub fn handle_profile_command(_command: ProfileCommands) -> Result<()> {
-    anyhow::bail!("Profile command not yet implemented (Task 4)")
+fn mask_api_key(key: &str) -> String {
+    if key.len() > 14 {
+        format!("{}...{}", &key[..10], &key[key.len() - 4..])
+    } else {
+        "***".to_string()
+    }
+}
+
+pub fn handle_profile_command(command: ProfileCommands) -> Result<()> {
+    use crate::credentials::{
+        delete_profile, get_active_profile, list_profiles, load_profile, save_profile,
+        set_active_profile, unset_profile_keys, ProfileValues,
+    };
+
+    match command {
+        ProfileCommands::List => {
+            let active = get_active_profile();
+            let profiles = list_profiles()?;
+            if profiles.is_empty() {
+                println!("No profiles found. Run `distri login` or `distri profile config set` to create one.");
+                return Ok(());
+            }
+            for (name, values) in &profiles {
+                let marker = if name == &active { "*" } else { " " };
+                let key_str = values
+                    .api_key
+                    .as_deref()
+                    .map(mask_api_key)
+                    .unwrap_or_else(|| "(none)".to_string());
+                let ws_str = values.workspace_id.as_deref().unwrap_or("(none)");
+                let url_str = values.api_url.as_deref().unwrap_or("https://api.distri.dev/v1");
+                println!(
+                    "{} {:<12}  api_key={:<20}  workspace={:<36}  url={}",
+                    marker, name, key_str, ws_str, url_str
+                );
+            }
+        }
+
+        ProfileCommands::Use { name } => {
+            let profiles = list_profiles()?;
+            let exists = profiles.iter().any(|(n, _)| n == &name);
+            if !exists {
+                anyhow::bail!(
+                    "Profile '{}' not found. Run `distri profile list` to see available profiles.",
+                    name
+                );
+            }
+            set_active_profile(&name)?;
+            println!("Active profile set to '{}'.", name);
+        }
+
+        ProfileCommands::Show { name } => {
+            let profile_name = name.unwrap_or_else(get_active_profile);
+            match load_profile(&profile_name)? {
+                None => {
+                    anyhow::bail!(
+                        "Profile '{}' not found. Run `distri profile list` to see available profiles.",
+                        profile_name
+                    );
+                }
+                Some(values) => {
+                    println!("Profile: {}", profile_name);
+                    println!(
+                        "  api_key      = {}",
+                        values
+                            .api_key
+                            .as_deref()
+                            .map(mask_api_key)
+                            .unwrap_or_else(|| "(not set)".to_string())
+                    );
+                    println!(
+                        "  workspace_id = {}",
+                        values.workspace_id.as_deref().unwrap_or("(not set)")
+                    );
+                    println!(
+                        "  api_url      = {}",
+                        values
+                            .api_url
+                            .as_deref()
+                            .unwrap_or("https://api.distri.dev/v1 (default)")
+                    );
+                }
+            }
+        }
+
+        ProfileCommands::Delete { name, yes } => {
+            let active = get_active_profile();
+            if name == active {
+                anyhow::bail!(
+                    "Cannot delete the active profile '{}'. Run `distri profile use <other>` first.",
+                    name
+                );
+            }
+            if !yes {
+                print!("Delete profile '{}'? [y/N] ", name);
+                std::io::stdout().flush().ok();
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input).ok();
+                if !input.trim().eq_ignore_ascii_case("y") {
+                    println!("Aborted.");
+                    return Ok(());
+                }
+            }
+            delete_profile(&name)?;
+            println!("Profile '{}' deleted.", name);
+        }
+
+        ProfileCommands::Config { command } => match command {
+            ProfileConfigCommands::Set {
+                profile,
+                api_key,
+                workspace_id,
+                api_url,
+            } => {
+                if api_key.is_none() && workspace_id.is_none() && api_url.is_none() {
+                    anyhow::bail!(
+                        "At least one of --api-key, --workspace-id, or --api-url is required."
+                    );
+                }
+                if let Some(ref ws) = workspace_id {
+                    uuid::Uuid::parse_str(ws).with_context(|| {
+                        format!("Invalid workspace_id: '{}' is not a valid UUID", ws)
+                    })?;
+                }
+                let profile_name = profile.unwrap_or_else(get_active_profile);
+                let values = ProfileValues {
+                    api_key,
+                    workspace_id,
+                    api_url,
+                };
+                save_profile(&profile_name, &values)?;
+                println!("Updated profile '{}'.", profile_name);
+            }
+
+            ProfileConfigCommands::Unset {
+                profile,
+                api_key,
+                workspace_id,
+                api_url,
+            } => {
+                if !api_key && !workspace_id && !api_url {
+                    anyhow::bail!(
+                        "At least one of --api-key, --workspace-id, or --api-url is required."
+                    );
+                }
+                let profile_name = profile.unwrap_or_else(get_active_profile);
+                unset_profile_keys(&profile_name, api_key, workspace_id, api_url)?;
+                println!("Unset keys from profile '{}'.", profile_name);
+            }
+        },
+    }
+    Ok(())
 }
 
 pub async fn handle_prompts_command(client: &Distri, command: PromptsCommands) -> Result<()> {

--- a/distri-cli/src/config.rs
+++ b/distri-cli/src/config.rs
@@ -36,4 +36,3 @@ pub fn load_last_model() -> Option<String> {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
 }
-

--- a/distri-cli/src/config.rs
+++ b/distri-cli/src/config.rs
@@ -1,7 +1,4 @@
-use std::path::{Path, PathBuf};
-
-use anyhow::{Context, Result};
-use distri::DistriConfig;
+use std::path::PathBuf;
 
 pub fn resolve_workspace(config_path: &Option<PathBuf>) -> PathBuf {
     config_path
@@ -40,69 +37,3 @@ pub fn load_last_model() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-pub fn normalize_optional(raw: &str) -> Option<String> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
-
-pub fn normalize_base_url(raw: &str) -> Option<String> {
-    normalize_optional(raw).map(|value| value.trim_end_matches('/').to_string())
-}
-
-pub fn set_client_config_value(key: &str, raw_value: &str) -> Result<PathBuf> {
-    let path = DistriConfig::config_path()
-        .ok_or_else(|| anyhow::anyhow!("Unable to resolve home directory for ~/.distri/config"))?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let mut config = load_client_config_value(&path);
-    let normalized = match key {
-        "api_key" => normalize_optional(raw_value),
-        "base_url" => normalize_base_url(raw_value),
-        "workspace_id" => {
-            let trimmed = normalize_optional(raw_value);
-            if let Some(ref value) = trimmed {
-                // Validate that it's a valid UUID
-                uuid::Uuid::parse_str(value).with_context(|| {
-                    format!("Invalid workspace_id: '{}' is not a valid UUID", value)
-                })?;
-            }
-            trimmed
-        }
-        _ => anyhow::bail!(
-            "Unknown config key '{}'. Supported keys: api_key, base_url, workspace_id",
-            key
-        ),
-    };
-
-    if let toml::Value::Table(ref mut table) = config {
-        match normalized {
-            Some(value) => {
-                table.insert(key.to_string(), toml::Value::String(value));
-            }
-            None => {
-                table.remove(key);
-            }
-        }
-    }
-
-    let contents = toml::to_string_pretty(&config)?;
-    std::fs::write(&path, contents)?;
-    Ok(path)
-}
-
-pub fn load_client_config_value(path: &Path) -> toml::Value {
-    let parsed = std::fs::read_to_string(path)
-        .ok()
-        .and_then(|contents| contents.parse::<toml::Value>().ok());
-
-    match parsed {
-        Some(toml::Value::Table(table)) => toml::Value::Table(table),
-        _ => toml::Value::Table(toml::map::Map::new()),
-    }
-}

--- a/distri-cli/src/credentials.rs
+++ b/distri-cli/src/credentials.rs
@@ -101,7 +101,7 @@ pub fn list_profiles() -> Result<Vec<(String, ProfileValues)>> {
 pub fn load_profile(name: &str) -> Result<Option<ProfileValues>> {
     let path = credentials_path().context("Unable to resolve home directory")?;
     let data = read_ini(&path);
-    Ok(data.get(name).map(|s| section_to_profile(s)))
+    Ok(data.get(name).map(section_to_profile))
 }
 
 /// Merge-save: only updates keys that are Some in `values`, leaves others untouched.
@@ -362,7 +362,10 @@ mod tests {
 
         assert_eq!(loaded.api_key, Some("my-api-key".to_string()));
         assert_eq!(loaded.workspace_id, Some("ws-123".to_string()));
-        assert_eq!(loaded.api_url, Some("https://api.example.com/v1".to_string()));
+        assert_eq!(
+            loaded.api_url,
+            Some("https://api.example.com/v1".to_string())
+        );
     }
 
     #[test]
@@ -376,7 +379,10 @@ mod tests {
             let section = data.entry("myprofile".to_string()).or_default();
             section.insert("api_key".to_string(), "original-key".to_string());
             section.insert("workspace_id".to_string(), "original-ws".to_string());
-            section.insert("api_url".to_string(), "https://original.example.com/v1".to_string());
+            section.insert(
+                "api_url".to_string(),
+                "https://original.example.com/v1".to_string(),
+            );
         }
         write_ini(&creds_path, &data).unwrap();
 
@@ -392,7 +398,10 @@ mod tests {
 
         assert_eq!(profile.api_key, Some("new-key".to_string()));
         assert_eq!(profile.workspace_id, Some("original-ws".to_string()));
-        assert_eq!(profile.api_url, Some("https://original.example.com/v1".to_string()));
+        assert_eq!(
+            profile.api_url,
+            Some("https://original.example.com/v1".to_string())
+        );
     }
 
     #[test]
@@ -419,12 +428,15 @@ mod tests {
 
         // Verify "default" still exists but "staging" is gone
         let result = read_ini(&creds_path);
-        assert!(result.contains_key("default"), "default profile should still exist");
-        assert!(!result.contains_key("staging"), "staging profile should be deleted");
-        assert_eq!(
-            result["default"]["api_key"],
-            "key-default"
+        assert!(
+            result.contains_key("default"),
+            "default profile should still exist"
         );
+        assert!(
+            !result.contains_key("staging"),
+            "staging profile should be deleted"
+        );
+        assert_eq!(result["default"]["api_key"], "key-default");
     }
 
     #[test]
@@ -494,19 +506,35 @@ active_profile = "default"
         let profile = section_to_profile(creds_data.get("default").unwrap());
         assert_eq!(profile.api_key, Some("legacy-key".to_string()));
         assert_eq!(profile.workspace_id, Some("legacy-ws".to_string()));
-        assert_eq!(profile.api_url, Some("https://legacy.example.com/v1".to_string()));
+        assert_eq!(
+            profile.api_url,
+            Some("https://legacy.example.com/v1".to_string())
+        );
 
         // Verify config file no longer contains legacy keys but still has active_profile
         let remaining_config = std::fs::read_to_string(&config_path).unwrap();
-        assert!(!remaining_config.contains("api_key"), "api_key should be removed from config");
-        assert!(!remaining_config.contains("workspace_id"), "workspace_id should be removed from config");
-        assert!(!remaining_config.contains("base_url"), "base_url should be removed from config");
-        assert!(remaining_config.contains("active_profile"), "active_profile should remain in config");
+        assert!(
+            !remaining_config.contains("api_key"),
+            "api_key should be removed from config"
+        );
+        assert!(
+            !remaining_config.contains("workspace_id"),
+            "workspace_id should be removed from config"
+        );
+        assert!(
+            !remaining_config.contains("base_url"),
+            "base_url should be removed from config"
+        );
+        assert!(
+            remaining_config.contains("active_profile"),
+            "active_profile should remain in config"
+        );
     }
 
     #[test]
     fn test_parse_ini_ignores_comments_and_blank_lines() {
-        let content = "# This is a comment\n\n[section]\n; another comment\nkey = value\n\nkey2 = value2\n";
+        let content =
+            "# This is a comment\n\n[section]\n; another comment\nkey = value\n\nkey2 = value2\n";
         let data = parse_ini(content);
         assert_eq!(data["section"]["key"], "value");
         assert_eq!(data["section"]["key2"], "value2");

--- a/distri-cli/src/credentials.rs
+++ b/distri-cli/src/credentials.rs
@@ -1,0 +1,501 @@
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const CREDENTIALS_FILE_NAME: &str = "credentials";
+const CONFIG_FILE_NAME: &str = "config";
+const CONFIG_DIR_NAME: &str = ".distri";
+const ENV_PROFILE: &str = "DISTRI_PROFILE";
+const DEFAULT_PROFILE: &str = "default";
+const DEFAULT_API_URL: &str = "https://api.distri.dev/v1";
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProfileValues {
+    pub api_key: Option<String>,
+    pub workspace_id: Option<String>,
+    pub api_url: Option<String>,
+}
+
+fn distri_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(CONFIG_DIR_NAME))
+}
+
+pub fn credentials_path() -> Option<PathBuf> {
+    Some(distri_dir()?.join(CREDENTIALS_FILE_NAME))
+}
+
+pub fn config_path() -> Option<PathBuf> {
+    Some(distri_dir()?.join(CONFIG_FILE_NAME))
+}
+
+type IniData = BTreeMap<String, BTreeMap<String, String>>;
+
+fn parse_ini(content: &str) -> IniData {
+    let mut data: IniData = BTreeMap::new();
+    let mut current_section = String::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            current_section = line[1..line.len() - 1].trim().to_string();
+            data.entry(current_section.clone()).or_default();
+        } else if let Some((k, v)) = line.split_once('=') {
+            let key = k.trim().to_string();
+            let value = v.trim().to_string();
+            if !current_section.is_empty() && !key.is_empty() {
+                data.entry(current_section.clone())
+                    .or_default()
+                    .insert(key, value);
+            }
+        }
+    }
+    data
+}
+
+fn serialize_ini(data: &IniData) -> String {
+    let mut out = String::new();
+    for (section, kv) in data {
+        out.push_str(&format!("[{}]\n", section));
+        for (k, v) in kv {
+            out.push_str(&format!("{} = {}\n", k, v));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn read_ini(path: &PathBuf) -> IniData {
+    std::fs::read_to_string(path)
+        .map(|s| parse_ini(&s))
+        .unwrap_or_default()
+}
+
+fn write_ini(path: &PathBuf, data: &IniData) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, serialize_ini(data))?;
+    Ok(())
+}
+
+fn section_to_profile(section: &BTreeMap<String, String>) -> ProfileValues {
+    ProfileValues {
+        api_key: section.get("api_key").cloned(),
+        workspace_id: section.get("workspace_id").cloned(),
+        api_url: section.get("api_url").cloned(),
+    }
+}
+
+pub fn list_profiles() -> Result<Vec<(String, ProfileValues)>> {
+    let path = credentials_path().context("Unable to resolve home directory")?;
+    let data = read_ini(&path);
+    Ok(data
+        .into_iter()
+        .map(|(name, section)| (name, section_to_profile(&section)))
+        .collect())
+}
+
+pub fn load_profile(name: &str) -> Result<Option<ProfileValues>> {
+    let path = credentials_path().context("Unable to resolve home directory")?;
+    let data = read_ini(&path);
+    Ok(data.get(name).map(|s| section_to_profile(s)))
+}
+
+/// Merge-save: only updates keys that are Some in `values`, leaves others untouched.
+pub fn save_profile(name: &str, values: &ProfileValues) -> Result<()> {
+    let path = credentials_path().context("Unable to resolve home directory")?;
+    let mut data = read_ini(&path);
+    let section = data.entry(name.to_string()).or_default();
+    if let Some(ref v) = values.api_key {
+        section.insert("api_key".to_string(), v.clone());
+    }
+    if let Some(ref v) = values.workspace_id {
+        section.insert("workspace_id".to_string(), v.clone());
+    }
+    if let Some(ref v) = values.api_url {
+        section.insert("api_url".to_string(), v.clone());
+    }
+    write_ini(&path, &data)
+}
+
+pub fn unset_profile_keys(
+    name: &str,
+    api_key: bool,
+    workspace_id: bool,
+    api_url: bool,
+) -> Result<()> {
+    let path = credentials_path().context("Unable to resolve home directory")?;
+    let mut data = read_ini(&path);
+    if let Some(section) = data.get_mut(name) {
+        if api_key {
+            section.remove("api_key");
+        }
+        if workspace_id {
+            section.remove("workspace_id");
+        }
+        if api_url {
+            section.remove("api_url");
+        }
+    }
+    write_ini(&path, &data)
+}
+
+pub fn delete_profile(name: &str) -> Result<()> {
+    let path = credentials_path().context("Unable to resolve home directory")?;
+    let mut data = read_ini(&path);
+    data.remove(name);
+    write_ini(&path, &data)
+}
+
+pub fn get_active_profile() -> String {
+    if let Ok(p) = std::env::var(ENV_PROFILE) {
+        let p = p.trim().to_string();
+        if !p.is_empty() {
+            return p;
+        }
+    }
+    config_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| {
+            s.lines().find_map(|line| {
+                let line = line.trim();
+                line.strip_prefix("active_profile")
+                    .and_then(|rest| rest.trim().strip_prefix('='))
+                    .map(|v| v.trim().trim_matches('"').to_string())
+            })
+        })
+        .unwrap_or_else(|| DEFAULT_PROFILE.to_string())
+}
+
+pub fn set_active_profile(name: &str) -> Result<()> {
+    let path = config_path().context("Unable to resolve home directory")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut lines: Vec<String> = existing.lines().map(|l| l.to_string()).collect();
+    let new_line = format!("active_profile = \"{}\"", name);
+    let pos = lines
+        .iter()
+        .position(|l| l.trim().starts_with("active_profile"));
+    match pos {
+        Some(i) => lines[i] = new_line,
+        None => lines.push(new_line),
+    }
+    std::fs::write(&path, lines.join("\n") + "\n")?;
+    Ok(())
+}
+
+pub fn migrate_legacy_config() -> Result<()> {
+    let config_path = match config_path() {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+    let creds_path = match credentials_path() {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+    if creds_path.exists() {
+        return Ok(());
+    }
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return Ok(()),
+    };
+    let mut api_key: Option<String> = None;
+    let mut workspace_id: Option<String> = None;
+    let mut base_url: Option<String> = None;
+    let mut remaining_lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("api_key") {
+            if let Some(v) = rest.trim().strip_prefix('=') {
+                api_key = Some(v.trim().trim_matches('"').to_string());
+                continue;
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix("workspace_id") {
+            if let Some(v) = rest.trim().strip_prefix('=') {
+                workspace_id = Some(v.trim().trim_matches('"').to_string());
+                continue;
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix("base_url") {
+            if let Some(v) = rest.trim().strip_prefix('=') {
+                base_url = Some(v.trim().trim_matches('"').to_string());
+                continue;
+            }
+        }
+        remaining_lines.push(line.to_string());
+    }
+    if api_key.is_some() || workspace_id.is_some() || base_url.is_some() {
+        let values = ProfileValues {
+            api_key,
+            workspace_id,
+            api_url: base_url,
+        };
+        save_profile(DEFAULT_PROFILE, &values)?;
+        std::fs::write(&config_path, remaining_lines.join("\n") + "\n")?;
+    }
+    Ok(())
+}
+
+pub fn load_config_with_profile() -> distri_types::DistriConfig {
+    use distri_types::DistriConfig;
+    let profile_name = get_active_profile();
+    let profile = load_profile(&profile_name)
+        .unwrap_or_default()
+        .unwrap_or_default();
+    let env_api_key = std::env::var("DISTRI_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let env_workspace_id = std::env::var("DISTRI_WORKSPACE_ID")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let env_base_url = std::env::var("DISTRI_BASE_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let base_url = env_base_url
+        .or(profile.api_url)
+        .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+    let api_key = env_api_key.or(profile.api_key);
+    let workspace_id = env_workspace_id.or(profile.workspace_id);
+    DistriConfig::new(base_url)
+        .with_maybe_api_key(api_key)
+        .with_maybe_workspace_id(workspace_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_temp_credentials(dir: &TempDir) -> PathBuf {
+        dir.path().join("credentials")
+    }
+
+    fn make_temp_config(dir: &TempDir) -> PathBuf {
+        dir.path().join("config")
+    }
+
+    #[test]
+    fn test_ini_round_trip() {
+        let content = "[default]\napi_key = abc123\nworkspace_id = ws-001\n\n[staging]\napi_key = stagingkey\n";
+        let parsed = parse_ini(content);
+
+        assert_eq!(parsed["default"]["api_key"], "abc123");
+        assert_eq!(parsed["default"]["workspace_id"], "ws-001");
+        assert_eq!(parsed["staging"]["api_key"], "stagingkey");
+
+        let serialized = serialize_ini(&parsed);
+        let reparsed = parse_ini(&serialized);
+
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn test_save_load_profile() {
+        let dir = TempDir::new().unwrap();
+        let creds_path = make_temp_credentials(&dir);
+
+        let values = ProfileValues {
+            api_key: Some("my-api-key".to_string()),
+            workspace_id: Some("ws-123".to_string()),
+            api_url: Some("https://api.example.com/v1".to_string()),
+        };
+
+        // Write directly using low-level helpers
+        let mut data: IniData = BTreeMap::new();
+        let section = data.entry("default".to_string()).or_default();
+        if let Some(ref v) = values.api_key {
+            section.insert("api_key".to_string(), v.clone());
+        }
+        if let Some(ref v) = values.workspace_id {
+            section.insert("workspace_id".to_string(), v.clone());
+        }
+        if let Some(ref v) = values.api_url {
+            section.insert("api_url".to_string(), v.clone());
+        }
+        write_ini(&creds_path, &data).unwrap();
+
+        // Read back using low-level helpers
+        let loaded_data = read_ini(&creds_path);
+        let loaded = loaded_data
+            .get("default")
+            .map(|s| section_to_profile(s))
+            .unwrap();
+
+        assert_eq!(loaded.api_key, Some("my-api-key".to_string()));
+        assert_eq!(loaded.workspace_id, Some("ws-123".to_string()));
+        assert_eq!(loaded.api_url, Some("https://api.example.com/v1".to_string()));
+    }
+
+    #[test]
+    fn test_merge_save_preserves_existing_keys() {
+        let dir = TempDir::new().unwrap();
+        let creds_path = make_temp_credentials(&dir);
+
+        // Set up initial profile with all three keys
+        let mut data: IniData = BTreeMap::new();
+        {
+            let section = data.entry("myprofile".to_string()).or_default();
+            section.insert("api_key".to_string(), "original-key".to_string());
+            section.insert("workspace_id".to_string(), "original-ws".to_string());
+            section.insert("api_url".to_string(), "https://original.example.com/v1".to_string());
+        }
+        write_ini(&creds_path, &data).unwrap();
+
+        // Now update only api_key (workspace_id and api_url should be preserved)
+        let mut existing = read_ini(&creds_path);
+        let section = existing.entry("myprofile".to_string()).or_default();
+        section.insert("api_key".to_string(), "new-key".to_string());
+        write_ini(&creds_path, &existing).unwrap();
+
+        // Verify workspace_id and api_url are untouched
+        let result = read_ini(&creds_path);
+        let profile = section_to_profile(result.get("myprofile").unwrap());
+
+        assert_eq!(profile.api_key, Some("new-key".to_string()));
+        assert_eq!(profile.workspace_id, Some("original-ws".to_string()));
+        assert_eq!(profile.api_url, Some("https://original.example.com/v1".to_string()));
+    }
+
+    #[test]
+    fn test_delete_profile() {
+        let dir = TempDir::new().unwrap();
+        let creds_path = make_temp_credentials(&dir);
+
+        // Set up two profiles
+        let mut data: IniData = BTreeMap::new();
+        {
+            let section = data.entry("default".to_string()).or_default();
+            section.insert("api_key".to_string(), "key-default".to_string());
+        }
+        {
+            let section = data.entry("staging".to_string()).or_default();
+            section.insert("api_key".to_string(), "key-staging".to_string());
+        }
+        write_ini(&creds_path, &data).unwrap();
+
+        // Delete only "staging"
+        let mut loaded = read_ini(&creds_path);
+        loaded.remove("staging");
+        write_ini(&creds_path, &loaded).unwrap();
+
+        // Verify "default" still exists but "staging" is gone
+        let result = read_ini(&creds_path);
+        assert!(result.contains_key("default"), "default profile should still exist");
+        assert!(!result.contains_key("staging"), "staging profile should be deleted");
+        assert_eq!(
+            result["default"]["api_key"],
+            "key-default"
+        );
+    }
+
+    #[test]
+    fn test_migrate_legacy_config() {
+        let dir = TempDir::new().unwrap();
+        let config_path = make_temp_config(&dir);
+        let creds_path = make_temp_credentials(&dir);
+
+        // Write a legacy config file
+        let legacy_content = r#"api_key = "legacy-key"
+workspace_id = "legacy-ws"
+base_url = "https://legacy.example.com/v1"
+active_profile = "default"
+"#;
+        std::fs::write(&config_path, legacy_content).unwrap();
+
+        // Perform migration manually using the low-level logic
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        let mut api_key: Option<String> = None;
+        let mut workspace_id: Option<String> = None;
+        let mut base_url: Option<String> = None;
+        let mut remaining_lines: Vec<String> = Vec::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("api_key") {
+                if let Some(v) = rest.trim().strip_prefix('=') {
+                    api_key = Some(v.trim().trim_matches('"').to_string());
+                    continue;
+                }
+            }
+            if let Some(rest) = trimmed.strip_prefix("workspace_id") {
+                if let Some(v) = rest.trim().strip_prefix('=') {
+                    workspace_id = Some(v.trim().trim_matches('"').to_string());
+                    continue;
+                }
+            }
+            if let Some(rest) = trimmed.strip_prefix("base_url") {
+                if let Some(v) = rest.trim().strip_prefix('=') {
+                    base_url = Some(v.trim().trim_matches('"').to_string());
+                    continue;
+                }
+            }
+            remaining_lines.push(line.to_string());
+        }
+
+        // Write credentials
+        if api_key.is_some() || workspace_id.is_some() || base_url.is_some() {
+            let mut creds_data: IniData = BTreeMap::new();
+            let section = creds_data.entry("default".to_string()).or_default();
+            if let Some(ref v) = api_key {
+                section.insert("api_key".to_string(), v.clone());
+            }
+            if let Some(ref v) = workspace_id {
+                section.insert("workspace_id".to_string(), v.clone());
+            }
+            if let Some(ref v) = base_url {
+                section.insert("api_url".to_string(), v.clone());
+            }
+            write_ini(&creds_path, &creds_data).unwrap();
+            std::fs::write(&config_path, remaining_lines.join("\n") + "\n").unwrap();
+        }
+
+        // Verify credentials file was created with the migrated values
+        assert!(creds_path.exists(), "credentials file should be created");
+        let creds_data = read_ini(&creds_path);
+        let profile = section_to_profile(creds_data.get("default").unwrap());
+        assert_eq!(profile.api_key, Some("legacy-key".to_string()));
+        assert_eq!(profile.workspace_id, Some("legacy-ws".to_string()));
+        assert_eq!(profile.api_url, Some("https://legacy.example.com/v1".to_string()));
+
+        // Verify config file no longer contains legacy keys but still has active_profile
+        let remaining_config = std::fs::read_to_string(&config_path).unwrap();
+        assert!(!remaining_config.contains("api_key"), "api_key should be removed from config");
+        assert!(!remaining_config.contains("workspace_id"), "workspace_id should be removed from config");
+        assert!(!remaining_config.contains("base_url"), "base_url should be removed from config");
+        assert!(remaining_config.contains("active_profile"), "active_profile should remain in config");
+    }
+
+    #[test]
+    fn test_parse_ini_ignores_comments_and_blank_lines() {
+        let content = "# This is a comment\n\n[section]\n; another comment\nkey = value\n\nkey2 = value2\n";
+        let data = parse_ini(content);
+        assert_eq!(data["section"]["key"], "value");
+        assert_eq!(data["section"]["key2"], "value2");
+        assert_eq!(data["section"].len(), 2);
+    }
+
+    #[test]
+    fn test_parse_ini_empty_file() {
+        let data = parse_ini("");
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_write_ini_creates_parent_dirs() {
+        let dir = TempDir::new().unwrap();
+        let nested_path = dir.path().join("a").join("b").join("credentials");
+        let mut data: IniData = BTreeMap::new();
+        data.entry("default".to_string())
+            .or_default()
+            .insert("api_key".to_string(), "test".to_string());
+        write_ini(&nested_path, &data).unwrap();
+        assert!(nested_path.exists());
+    }
+}

--- a/distri-cli/src/credentials.rs
+++ b/distri-cli/src/credentials.rs
@@ -271,7 +271,39 @@ pub fn load_config_with_profile() -> distri_types::DistriConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TempHomeGuard {
+        original: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for TempHomeGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                #[allow(unsafe_code)]
+                Some(v) => unsafe { std::env::set_var("HOME", v) },
+                #[allow(unsafe_code)]
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+
+    fn temp_home(path: &std::path::Path) -> TempHomeGuard {
+        let lock = HOME_LOCK.lock().unwrap();
+        let original = std::env::var_os("HOME");
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("HOME", path);
+        }
+        TempHomeGuard {
+            original,
+            _lock: lock,
+        }
+    }
 
     fn make_temp_credentials(dir: &TempDir) -> PathBuf {
         dir.path().join("credentials")
@@ -497,5 +529,124 @@ active_profile = "default"
             .insert("api_key".to_string(), "test".to_string());
         write_ini(&nested_path, &data).unwrap();
         assert!(nested_path.exists());
+    }
+
+    #[test]
+    fn test_public_api_save_and_load() {
+        let dir = TempDir::new().unwrap();
+        // Temporarily redirect HOME so credentials_path() and config_path() point to temp dir
+        let _guard = temp_home(dir.path());
+
+        let values = ProfileValues {
+            api_key: Some("dak_integration_test".to_string()),
+            workspace_id: Some("00000000-0000-0000-0000-000000000001".to_string()),
+            api_url: Some("https://api.distri.dev/v1".to_string()),
+        };
+        save_profile("default", &values).unwrap();
+
+        let loaded = load_profile("default").unwrap().unwrap();
+        assert_eq!(loaded.api_key.as_deref(), Some("dak_integration_test"));
+        assert_eq!(
+            loaded.workspace_id.as_deref(),
+            Some("00000000-0000-0000-0000-000000000001")
+        );
+
+        let profiles = list_profiles().unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].0, "default");
+    }
+
+    #[test]
+    fn test_public_api_merge_save() {
+        let dir = TempDir::new().unwrap();
+        let _guard = temp_home(dir.path());
+
+        // Write initial profile
+        save_profile(
+            "default",
+            &ProfileValues {
+                api_key: Some("original_key".to_string()),
+                workspace_id: Some("ws-original".to_string()),
+                api_url: None,
+            },
+        )
+        .unwrap();
+
+        // Update only api_key
+        save_profile(
+            "default",
+            &ProfileValues {
+                api_key: Some("new_key".to_string()),
+                workspace_id: None,
+                api_url: None,
+            },
+        )
+        .unwrap();
+
+        let loaded = load_profile("default").unwrap().unwrap();
+        assert_eq!(loaded.api_key.as_deref(), Some("new_key"));
+        assert_eq!(loaded.workspace_id.as_deref(), Some("ws-original")); // preserved
+    }
+
+    #[test]
+    fn test_public_api_delete_profile() {
+        let dir = TempDir::new().unwrap();
+        let _guard = temp_home(dir.path());
+
+        save_profile(
+            "keep",
+            &ProfileValues {
+                api_key: Some("k1".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        save_profile(
+            "remove",
+            &ProfileValues {
+                api_key: Some("k2".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        delete_profile("remove").unwrap();
+
+        let profiles = list_profiles().unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].0, "keep");
+    }
+
+    #[test]
+    fn test_public_api_migrate_legacy_config() {
+        let dir = TempDir::new().unwrap();
+        let _guard = temp_home(dir.path());
+
+        // Write a legacy-style config
+        let config_dir = dir.path().join(".distri");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config"),
+            "api_key = \"dak_legacy\"\nworkspace_id = \"legacy-ws-id\"\n",
+        )
+        .unwrap();
+
+        // Run migration
+        migrate_legacy_config().unwrap();
+
+        // Credentials file should now exist with [default] section
+        let creds = load_profile("default").unwrap().unwrap();
+        assert_eq!(creds.api_key.as_deref(), Some("dak_legacy"));
+        assert_eq!(creds.workspace_id.as_deref(), Some("legacy-ws-id"));
+
+        // Config file should no longer have api_key or workspace_id
+        let config_content = std::fs::read_to_string(config_dir.join("config")).unwrap();
+        assert!(!config_content.contains("api_key"));
+        assert!(!config_content.contains("workspace_id"));
+
+        // Running migration again should be a no-op (credentials file already exists)
+        migrate_legacy_config().unwrap();
+        let creds_again = load_profile("default").unwrap().unwrap();
+        assert_eq!(creds_again.api_key.as_deref(), Some("dak_legacy")); // unchanged
     }
 }

--- a/distri-cli/src/login.rs
+++ b/distri-cli/src/login.rs
@@ -21,7 +21,11 @@ struct CallbackQuery {
 /// 4. User logs in on the web and selects a workspace
 /// 5. Web redirects back to localhost with credentials
 /// 6. Saves the API key and workspace_id to ~/.distri/credentials
-pub async fn handle_login_command(_email: Option<String>, _skip_workspace: bool, profile: Option<String>) -> Result<()> {
+pub async fn handle_login_command(
+    _email: Option<String>,
+    _skip_workspace: bool,
+    profile: Option<String>,
+) -> Result<()> {
     // Get the login URL from the API server first
     println!("Connecting to Distri Cloud...");
     let client = Distri::from_env();
@@ -118,7 +122,12 @@ pub async fn handle_login_command(_email: Option<String>, _skip_workspace: bool,
 
     // Save credentials to profile
     let profile_name = profile.as_deref().unwrap_or("default");
-    save_credentials(profile_name, &api_key, &workspace_id, &login_url_response.login_url)?;
+    save_credentials(
+        profile_name,
+        &api_key,
+        &workspace_id,
+        &login_url_response.login_url,
+    )?;
 
     println!("\n✓ Successfully authenticated!");
     println!("  Profile:      {}", profile_name);

--- a/distri-cli/src/login.rs
+++ b/distri-cli/src/login.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
-use distri::{Distri, DistriConfig};
+use distri::Distri;
 use serde::Deserialize;
-use std::path::PathBuf;
 use tokio::sync::oneshot;
 use warp::Filter;
 
@@ -21,8 +20,8 @@ struct CallbackQuery {
 /// 3. Opens the browser to the Distri Cloud login page
 /// 4. User logs in on the web and selects a workspace
 /// 5. Web redirects back to localhost with credentials
-/// 6. Saves the API key and workspace_id to ~/.distri/config
-pub async fn handle_login_command(_email: Option<String>, _skip_workspace: bool) -> Result<()> {
+/// 6. Saves the API key and workspace_id to ~/.distri/credentials
+pub async fn handle_login_command(_email: Option<String>, _skip_workspace: bool, profile: Option<String>) -> Result<()> {
     // Get the login URL from the API server first
     println!("Connecting to Distri Cloud...");
     let client = Distri::from_env();
@@ -117,12 +116,14 @@ pub async fn handle_login_command(_email: Option<String>, _skip_workspace: bool)
     });
     let (api_key, workspace_id) = creds?;
 
-    // Save config
-    save_config(&api_key, &workspace_id)?;
+    // Save credentials to profile
+    let profile_name = profile.as_deref().unwrap_or("default");
+    save_credentials(profile_name, &api_key, &workspace_id, &login_url_response.login_url)?;
 
     println!("\n✓ Successfully authenticated!");
+    println!("  Profile:      {}", profile_name);
     println!(
-        "  API Key: {}...{}",
+        "  API Key:      {}...{}",
         &api_key[..10],
         &api_key[api_key.len() - 4..]
     );
@@ -154,41 +155,26 @@ fn open_browser(url: &str) -> Result<()> {
     Ok(())
 }
 
-/// Save the API key and workspace_id to ~/.distri/config.
-fn save_config(api_key: &str, workspace_id: &str) -> Result<()> {
-    let path = DistriConfig::config_path().context("Unable to resolve ~/.distri/config path")?;
+fn save_credentials(
+    profile_name: &str,
+    api_key: &str,
+    workspace_id: &str,
+    login_url: &str,
+) -> Result<()> {
+    // Extract the api_url from the login_url (strip the /cli-login path)
+    let api_url = login_url
+        .split("/cli-login")
+        .next()
+        .unwrap_or("https://api.distri.dev")
+        .trim_end_matches('/')
+        .to_string()
+        + "/v1";
 
-    // Create parent directory
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    // Load existing config or create new
-    let mut config = load_config_toml(&path);
-
-    // Update values
-    if let toml::Value::Table(ref mut table) = config {
-        table.insert(
-            "api_key".to_string(),
-            toml::Value::String(api_key.to_string()),
-        );
-        table.insert(
-            "workspace_id".to_string(),
-            toml::Value::String(workspace_id.to_string()),
-        );
-    }
-
-    // Write to file
-    let contents = toml::to_string_pretty(&config)?;
-    std::fs::write(&path, contents)?;
-
+    let values = crate::credentials::ProfileValues {
+        api_key: Some(api_key.to_string()),
+        workspace_id: Some(workspace_id.to_string()),
+        api_url: Some(api_url),
+    };
+    crate::credentials::save_profile(profile_name, &values)?;
     Ok(())
-}
-
-/// Load the existing config file as a TOML value, or create an empty table.
-fn load_config_toml(path: &PathBuf) -> toml::Value {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|contents| contents.parse::<toml::Value>().ok())
-        .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()))
 }

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -11,6 +11,7 @@ use tokio::fs;
 mod chat;
 mod commands;
 mod config;
+mod credentials;
 mod input;
 mod logging;
 mod login;

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -3,9 +3,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use distri::{
-    print_stream_verbose, AgentStreamClient, BuildHttpClient, Distri, DistriClientApp,
-};
+use distri::{AgentStreamClient, BuildHttpClient, Distri, DistriClientApp, print_stream_verbose};
 use tokio::fs;
 
 mod chat;
@@ -22,13 +20,13 @@ mod traces;
 
 use chat::run_interactive_chat;
 use commands::{
-    handle_config_command, handle_connections_command, handle_prompts_command,
+    handle_connections_command, handle_profile_command, handle_prompts_command,
     handle_secrets_command, handle_skills_command, handle_workflow_command, push_file,
 };
 use config::resolve_workspace;
 use message::{build_connections_context, build_message_params};
 use threads::resolve_resume_arg;
-use tools::{register_all, register_approval_handler, validate_external_tools, LOCAL_TOOL_NAMES};
+use tools::{LOCAL_TOOL_NAMES, register_all, register_approval_handler, validate_external_tools};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about)]
@@ -141,10 +139,10 @@ enum Commands {
         command: TracesCommands,
     },
 
-    /// Manage local client configuration
-    Config {
+    /// Manage authentication profiles
+    Profile {
         #[clap(subcommand)]
-        command: ConfigCommands,
+        command: ProfileCommands,
     },
 
     /// Workflow execution commands
@@ -159,6 +157,11 @@ enum Commands {
         email: Option<String>,
         #[clap(long, help = "Skip workspace selection (use default)")]
         skip_workspace: bool,
+        #[clap(
+            long,
+            help = "Profile name to save credentials into (default: \"default\")"
+        )]
+        profile: Option<String>,
     },
 
     /// Start the local server (delegates to distri-server)
@@ -216,13 +219,56 @@ enum ToolsCommands {
 }
 
 #[derive(Subcommand, Debug, Clone)]
-pub(crate) enum ConfigCommands {
-    /// Set a config value in ~/.distri/config
+pub(crate) enum ProfileCommands {
+    /// List all profiles
+    List,
+    /// Set the active profile
+    Use {
+        #[clap(help = "Profile name")]
+        name: String,
+    },
+    /// Show profile values (active profile if no name given)
+    Show {
+        #[clap(help = "Profile name (defaults to active)")]
+        name: Option<String>,
+    },
+    /// Delete a profile
+    Delete {
+        #[clap(help = "Profile name")]
+        name: String,
+        #[clap(long, short, help = "Skip confirmation prompt")]
+        yes: bool,
+    },
+    /// Manage credential keys within a profile
+    Config {
+        #[clap(subcommand)]
+        command: ProfileConfigCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum ProfileConfigCommands {
+    /// Set one or more credential keys on a profile
     Set {
-        #[clap(help = "Config key (api_key, base_url, workspace_id)")]
-        key: String,
-        #[clap(help = "Value to set (empty clears the key)", num_args = 1..)]
-        value: Vec<String>,
+        #[clap(long, help = "Target profile (defaults to active)")]
+        profile: Option<String>,
+        #[clap(long, help = "API key")]
+        api_key: Option<String>,
+        #[clap(long, help = "Workspace ID (UUID)")]
+        workspace_id: Option<String>,
+        #[clap(long, help = "API URL")]
+        api_url: Option<String>,
+    },
+    /// Remove one or more credential keys from a profile
+    Unset {
+        #[clap(long, help = "Target profile (defaults to active)")]
+        profile: Option<String>,
+        #[clap(long, help = "Remove api_key")]
+        api_key: bool,
+        #[clap(long, help = "Remove workspace_id")]
+        workspace_id: bool,
+        #[clap(long, help = "Remove api_url")]
+        api_url: bool,
     },
 }
 
@@ -642,14 +688,15 @@ async fn main() -> Result<()> {
                 println!("{}", serde_json::to_string_pretty(&result)?);
             }
         },
-        Commands::Config { command } => {
-            handle_config_command(command)?;
+        Commands::Profile { command } => {
+            handle_profile_command(command)?;
         }
         Commands::Login {
             email,
             skip_workspace,
+            profile,
         } => {
-            login::handle_login_command(email, skip_workspace).await?;
+            login::handle_login_command(email, skip_workspace, profile).await?;
         }
         Commands::Prompts { command } => {
             handle_prompts_command(&client, command).await?;

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use distri::{
-    print_stream_verbose, AgentStreamClient, BuildHttpClient, Distri, DistriClientApp, DistriConfig,
+    print_stream_verbose, AgentStreamClient, BuildHttpClient, Distri, DistriClientApp,
 };
 use tokio::fs;
 
@@ -383,7 +383,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let mut config = DistriConfig::from_env();
+    // Run one-time migration of legacy ~/.distri/config keys to ~/.distri/credentials
+    let _ = crate::credentials::migrate_legacy_config();
+    let mut config = crate::credentials::load_config_with_profile();
     if let Some(base_url) = cli.base_url.as_deref() {
         config.base_url = base_url.trim_end_matches('/').to_string();
     }

--- a/distri-formatter/src/lib.rs
+++ b/distri-formatter/src/lib.rs
@@ -89,28 +89,28 @@ pub trait Formatter: Send + Sync {
         if message.role != distri_types::MessageRole::Assistant {
             return;
         }
-        if let Some(text) = message.as_text() {
-            if !text.is_empty() {
-                // Replace accumulated content with the final answer.
-                self.clear_content();
-                self.handle_event(&distri_types::AgentEvent {
-                    timestamp: chrono::Utc::now(),
-                    thread_id: String::new(),
-                    run_id: String::new(),
-                    event: distri_types::AgentEventType::TextMessageContent {
-                        message_id: message.id.clone(),
-                        step_id: String::new(),
-                        delta: text,
-                        stripped_content: None,
-                    },
-                    task_id: String::new(),
-                    agent_id: String::new(),
-                    user_id: None,
-                    identifier_id: None,
-                    workspace_id: None,
-                    channel_id: None,
-                });
-            }
+        if let Some(text) = message.as_text()
+            && !text.is_empty()
+        {
+            // Replace accumulated content with the final answer.
+            self.clear_content();
+            self.handle_event(&distri_types::AgentEvent {
+                timestamp: chrono::Utc::now(),
+                thread_id: String::new(),
+                run_id: String::new(),
+                event: distri_types::AgentEventType::TextMessageContent {
+                    message_id: message.id.clone(),
+                    step_id: String::new(),
+                    delta: text,
+                    stripped_content: None,
+                },
+                task_id: String::new(),
+                agent_id: String::new(),
+                user_id: None,
+                identifier_id: None,
+                workspace_id: None,
+                channel_id: None,
+            });
         }
     }
 }

--- a/distri-formatter/src/renderers/mod.rs
+++ b/distri-formatter/src/renderers/mod.rs
@@ -87,27 +87,27 @@ pub fn render_tool_output(result: &ToolResponse, verbose: bool) {
 fn render_todos(result: &ToolResponse) {
     use distri_types::Part;
     for part in &result.parts {
-        if let Part::Data(value) = part {
-            if let Some(todos) = value.get("todos").and_then(|v| v.as_array()) {
-                println!("{}{}Updated Plan{}", COLOR_GRAY, RESULT_PREFIX, COLOR_RESET);
-                for todo in todos {
-                    let content = todo
-                        .get("content")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("(missing)");
-                    let status = todo
-                        .get("status")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("pending");
-                    let icon = match status {
-                        "completed" | "done" => "■",
-                        "in_progress" => "◐",
-                        _ => "□",
-                    };
-                    println!("{}  {} {}{}", COLOR_GRAY, icon, content, COLOR_RESET);
-                }
-                return;
+        if let Part::Data(value) = part
+            && let Some(todos) = value.get("todos").and_then(|v| v.as_array())
+        {
+            println!("{}{}Updated Plan{}", COLOR_GRAY, RESULT_PREFIX, COLOR_RESET);
+            for todo in todos {
+                let content = todo
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(missing)");
+                let status = todo
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("pending");
+                let icon = match status {
+                    "completed" | "done" => "■",
+                    "in_progress" => "◐",
+                    _ => "□",
+                };
+                println!("{}  {} {}{}", COLOR_GRAY, icon, content, COLOR_RESET);
             }
+            return;
         }
     }
     render_tool_result(result);

--- a/distri-formatter/src/telegram.rs
+++ b/distri-formatter/src/telegram.rs
@@ -147,10 +147,10 @@ impl SurfaceRenderer for TelegramRenderer {
                     })
                     .collect();
                 // Attach media to last chunk.
-                if !media.is_empty() {
-                    if let Some(RendererOutput::RichText { media: m, .. }) = parts.last_mut() {
-                        *m = media;
-                    }
+                if !media.is_empty()
+                    && let Some(RendererOutput::RichText { media: m, .. }) = parts.last_mut()
+                {
+                    *m = media;
                 }
                 return RendererOutput::Chunks(parts);
             }

--- a/distri-types/src/agent.rs
+++ b/distri-types/src/agent.rs
@@ -803,8 +803,8 @@ impl ToolsConfig {
     }
 }
 
-/// Where filesystem and artifact tools should execute.
-/// Deprecated: filesystem tools are no longer included as server builtins.
+// Where filesystem and artifact tools should execute.
+// Deprecated: filesystem tools are no longer included as server builtins.
 
 /// Configuration for tools from an MCP server
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/distri-types/src/client_config.rs
+++ b/distri-types/src/client_config.rs
@@ -165,15 +165,19 @@ impl DistriConfig {
         self
     }
 
-    /// Set the API key if Some.
+    /// Set the API key if Some. Does not change the value when None.
     pub fn with_maybe_api_key(mut self, api_key: Option<String>) -> Self {
-        self.api_key = api_key;
+        if api_key.is_some() {
+            self.api_key = api_key;
+        }
         self
     }
 
-    /// Set the workspace ID if Some.
+    /// Set the workspace ID if Some. Does not change the value when None.
     pub fn with_maybe_workspace_id(mut self, workspace_id: Option<String>) -> Self {
-        self.workspace_id = workspace_id;
+        if workspace_id.is_some() {
+            self.workspace_id = workspace_id;
+        }
         self
     }
 

--- a/distri-types/src/client_config.rs
+++ b/distri-types/src/client_config.rs
@@ -165,6 +165,18 @@ impl DistriConfig {
         self
     }
 
+    /// Set the API key if Some.
+    pub fn with_maybe_api_key(mut self, api_key: Option<String>) -> Self {
+        self.api_key = api_key;
+        self
+    }
+
+    /// Set the workspace ID if Some.
+    pub fn with_maybe_workspace_id(mut self, workspace_id: Option<String>) -> Self {
+        self.workspace_id = workspace_id;
+        self
+    }
+
     /// Set the request timeout in seconds.
     pub fn with_timeout(mut self, timeout_secs: u64) -> Self {
         self.timeout_secs = timeout_secs;

--- a/distri-types/src/configuration/package.rs
+++ b/distri-types/src/configuration/package.rs
@@ -49,6 +49,7 @@ pub struct AgentConfigWithTools {
 /// Unified agent configuration enum
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]
 #[serde(tag = "agent_type", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum AgentConfig {
     /// Standard markdown-based agent
     #[schema(value_type = Object)]

--- a/distri-types/src/core.rs
+++ b/distri-types/src/core.rs
@@ -136,6 +136,7 @@ impl From<async_openai::types::chat::Role> for MessageRole {
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "part_type", content = "data")]
+#[allow(clippy::large_enum_variant)]
 pub enum Part {
     Text(String),
     ToolCall(ToolCall),
@@ -363,6 +364,7 @@ impl Message {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum TaskMessage {
     Message(Message),
     Event(TaskEvent),

--- a/distri-types/src/events.rs
+++ b/distri-types/src/events.rs
@@ -69,6 +69,7 @@ impl AgentEvent {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", tag = "type")]
+#[allow(clippy::large_enum_variant)]
 pub enum AgentEventType {
     /// Verbose diagnostic message streamed from server to client (only emitted when verbose=true).
     DiagnosticLog {

--- a/distri-types/src/orchestrator.rs
+++ b/distri-types/src/orchestrator.rs
@@ -54,6 +54,12 @@ pub struct OrchestratorRef {
     inner: std::sync::RwLock<Option<Arc<dyn OrchestratorTrait>>>,
 }
 
+impl Default for OrchestratorRef {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OrchestratorRef {
     /// Create a new orchestrator reference without an actual orchestrator
     pub fn new() -> Self {

--- a/distri-types/src/prompt.rs
+++ b/distri-types/src/prompt.rs
@@ -637,7 +637,7 @@ fn compute_hash(content: &str) -> String {
 /// Standalone function for use outside of distri-core's TokenEstimator.
 #[inline]
 pub fn rough_token_count(text: &str) -> usize {
-    (text.len() + 3) / 4
+    text.len().div_ceil(4)
 }
 
 /// Result of rendering a template with budget tracking.
@@ -709,10 +709,10 @@ pub async fn build_prompt_messages_with_budget<'a>(
     let system_msg = Message::system(system_result.content, None);
 
     let mut user_msg = user_message.clone();
-    if user_msg.parts.is_empty() {
-        if let Some(text) = user_message.as_text() {
-            user_msg.parts.push(Part::Text(text));
-        }
+    if user_msg.parts.is_empty()
+        && let Some(text) = user_message.as_text()
+    {
+        user_msg.parts.push(Part::Text(text));
     }
     if !user_result.content.is_empty() {
         user_msg.parts.push(Part::Text(user_result.content));
@@ -744,7 +744,7 @@ pub async fn build_prompt_messages_with_budget<'a>(
         if let Some(todos) = &template_data.todos {
             dynamic_chars += todos.len();
         }
-        (dynamic_chars + 3) / 4
+        dynamic_chars.div_ceil(4)
     };
     let static_tokens = prompt_only_tokens.saturating_sub(dynamic_content_tokens);
 

--- a/distri-types/src/skill.rs
+++ b/distri-types/src/skill.rs
@@ -33,6 +33,7 @@ pub struct Skill {
 }
 
 impl Skill {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         name: String,

--- a/distri-types/src/tool_result_store/mod.rs
+++ b/distri-types/src/tool_result_store/mod.rs
@@ -74,12 +74,11 @@ impl ContentFormat {
 
         // Try JSON
         let trimmed = content.trim();
-        if (trimmed.starts_with('{') && trimmed.ends_with('}'))
-            || (trimmed.starts_with('[') && trimmed.ends_with(']'))
+        if ((trimmed.starts_with('{') && trimmed.ends_with('}'))
+            || (trimmed.starts_with('[') && trimmed.ends_with(']')))
+            && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
         {
-            if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
-                return Self::Json;
-            }
+            return Self::Json;
         }
 
         // Markdown heuristic: has headings or frontmatter
@@ -276,12 +275,13 @@ fn generate_markdown_preview(content: &str, max_bytes: usize) -> String {
             content_lines = 0;
             result.push_str(line);
             result.push('\n');
-        } else if in_content && content_lines < max_content_lines_per_section {
-            if !line.trim().is_empty() {
-                content_lines += 1;
-                result.push_str(line);
-                result.push('\n');
-            }
+        } else if in_content
+            && content_lines < max_content_lines_per_section
+            && !line.trim().is_empty()
+        {
+            content_lines += 1;
+            result.push_str(line);
+            result.push('\n');
         }
 
         // If we've seen enough headings and content, stop

--- a/distri-workflow/src/resolve.rs
+++ b/distri-workflow/src/resolve.rs
@@ -205,7 +205,7 @@ fn is_truthy(value: &Option<Value>) -> bool {
         Some(Value::Null) => false,
         Some(Value::Bool(b)) => *b,
         Some(Value::String(s)) => !s.is_empty(),
-        Some(Value::Number(n)) => n.as_f64().map_or(false, |f| f != 0.0),
+        Some(Value::Number(n)) => n.as_f64().is_some_and(|f| f != 0.0),
         Some(Value::Array(a)) => !a.is_empty(),
         Some(Value::Object(o)) => !o.is_empty(),
     }

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -76,6 +76,12 @@ pub struct Distri {
     config: DistriConfig,
 }
 
+impl Default for Distri {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Distri {
     /// Create a new client using the default base URL (https://api.distri.dev/v1).
     pub fn new() -> Self {

--- a/distri/src/config.rs
+++ b/distri/src/config.rs
@@ -51,10 +51,10 @@ impl BuildHttpClient for DistriConfig {
 
         // Propagate W3C Trace Context when a traceparent is provided.
         // Set via --traceparent CLI flag (SandboxLauncher passes it to distri run).
-        if let Some(ref traceparent) = self.traceparent {
-            if let Ok(val) = reqwest::header::HeaderValue::from_str(traceparent) {
-                headers.insert("traceparent", val);
-            }
+        if let Some(ref traceparent) = self.traceparent
+            && let Ok(val) = reqwest::header::HeaderValue::from_str(traceparent)
+        {
+            headers.insert("traceparent", val);
         }
 
         if !headers.is_empty() {

--- a/docs/superpowers/plans/2026-04-07-cli-profiles.md
+++ b/docs/superpowers/plans/2026-04-07-cli-profiles.md
@@ -1,0 +1,1136 @@
+# CLI Profiles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the single `~/.distri/config` credential store with a named-profile system (AWS-style INI `~/.distri/credentials`), with full CLI management under `distri profile`.
+
+**Architecture:** A new `credentials.rs` module in `distri-cli` owns all profile file I/O — INI read/write, active-profile tracking, and legacy migration. `DistriConfig` loading in `main.rs` is replaced with `load_config_with_profile()` from `credentials.rs` that merges the active profile with env var overrides. All profile commands live under `Commands::Profile` in `main.rs` / `handle_profile_command` in `commands.rs`.
+
+**Tech Stack:** Rust, hand-written INI parser (no new dep), existing `toml` crate for `~/.distri/config`, `clap` for CLI.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `distri-cli/src/credentials.rs` | INI parse/write, `ProfileValues`, `list_profiles`, `load_profile`, `save_profile`, `delete_profile`, `get_active_profile`, `set_active_profile`, `load_config_with_profile`, `migrate_legacy_config` |
+| Modify | `distri-cli/src/commands.rs` | Remove `handle_config_command`, add `handle_profile_command` |
+| Modify | `distri-cli/src/main.rs` | Replace `Commands::Config` with `Commands::Profile`, add `--profile` to `Login`, wire `load_config_with_profile()` |
+| Modify | `distri-cli/src/login.rs` | Accept `profile_name: &str`, save to `credentials.rs` instead of TOML config |
+| Modify | `distri-cli/src/config.rs` | Remove `set_client_config_value` and `load_client_config_value` |
+
+---
+
+### Task 1: Create `credentials.rs` — INI parser and ProfileValues
+
+**Files:**
+- Create: `distri/distri-cli/src/credentials.rs`
+- Test: inside the same file under `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `distri/distri-cli/src/credentials.rs`:
+
+```rust
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+const CREDENTIALS_FILE_NAME: &str = "credentials";
+const CONFIG_FILE_NAME: &str = "config";
+const CONFIG_DIR_NAME: &str = ".distri";
+const ENV_PROFILE: &str = "DISTRI_PROFILE";
+const DEFAULT_PROFILE: &str = "default";
+const DEFAULT_API_URL: &str = "https://api.distri.dev/v1";
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProfileValues {
+    pub api_key: Option<String>,
+    pub workspace_id: Option<String>,
+    pub api_url: Option<String>,
+}
+
+fn distri_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(PathBuf::from(home).join(CONFIG_DIR_NAME))
+}
+
+pub fn credentials_path() -> Option<PathBuf> {
+    Some(distri_dir()?.join(CREDENTIALS_FILE_NAME))
+}
+
+pub fn config_path() -> Option<PathBuf> {
+    Some(distri_dir()?.join(CONFIG_FILE_NAME))
+}
+
+// ---------------------------------------------------------------------------
+// INI parser — handles [section] headers and key = value lines.
+// Lines starting with # or ; are comments. Blank lines are ignored.
+// ---------------------------------------------------------------------------
+
+type IniData = BTreeMap<String, BTreeMap<String, String>>;
+
+fn parse_ini(content: &str) -> IniData {
+    let mut data: IniData = BTreeMap::new();
+    let mut current_section = String::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            current_section = line[1..line.len() - 1].trim().to_string();
+            data.entry(current_section.clone()).or_default();
+        } else if let Some((k, v)) = line.split_once('=') {
+            let key = k.trim().to_string();
+            let value = v.trim().to_string();
+            if !current_section.is_empty() && !key.is_empty() {
+                data.entry(current_section.clone())
+                    .or_default()
+                    .insert(key, value);
+            }
+        }
+    }
+    data
+}
+
+fn serialize_ini(data: &IniData) -> String {
+    let mut out = String::new();
+    for (section, kv) in data {
+        out.push_str(&format!("[{}]\n", section));
+        for (k, v) in kv {
+            out.push_str(&format!("{} = {}\n", k, v));
+        }
+        out.push('\n');
+    }
+    out
+}
+
+fn read_ini(path: &PathBuf) -> IniData {
+    std::fs::read_to_string(path)
+        .map(|s| parse_ini(&s))
+        .unwrap_or_default()
+}
+
+fn write_ini(path: &PathBuf, data: &IniData) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, serialize_ini(data))?;
+    Ok(())
+}
+
+fn section_to_profile(section: &BTreeMap<String, String>) -> ProfileValues {
+    ProfileValues {
+        api_key: section.get("api_key").cloned(),
+        workspace_id: section.get("workspace_id").cloned(),
+        api_url: section.get("api_url").cloned(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+pub fn list_profiles() -> Result<Vec<(String, ProfileValues)>> {
+    let path = credentials_path()
+        .context("Unable to resolve home directory")?;
+    let data = read_ini(&path);
+    Ok(data
+        .into_iter()
+        .map(|(name, section)| (name, section_to_profile(&section)))
+        .collect())
+}
+
+pub fn load_profile(name: &str) -> Result<Option<ProfileValues>> {
+    let path = credentials_path()
+        .context("Unable to resolve home directory")?;
+    let data = read_ini(&path);
+    Ok(data.get(name).map(|s| section_to_profile(s)))
+}
+
+/// Merge-save: only updates keys that are Some in `values`, leaves others untouched.
+pub fn save_profile(name: &str, values: &ProfileValues) -> Result<()> {
+    let path = credentials_path()
+        .context("Unable to resolve home directory")?;
+    let mut data = read_ini(&path);
+    let section = data.entry(name.to_string()).or_default();
+    if let Some(ref v) = values.api_key {
+        section.insert("api_key".to_string(), v.clone());
+    }
+    if let Some(ref v) = values.workspace_id {
+        section.insert("workspace_id".to_string(), v.clone());
+    }
+    if let Some(ref v) = values.api_url {
+        section.insert("api_url".to_string(), v.clone());
+    }
+    write_ini(&path, &data)
+}
+
+/// Remove specific keys from a profile (keys with `true` are removed).
+pub fn unset_profile_keys(
+    name: &str,
+    api_key: bool,
+    workspace_id: bool,
+    api_url: bool,
+) -> Result<()> {
+    let path = credentials_path()
+        .context("Unable to resolve home directory")?;
+    let mut data = read_ini(&path);
+    if let Some(section) = data.get_mut(name) {
+        if api_key { section.remove("api_key"); }
+        if workspace_id { section.remove("workspace_id"); }
+        if api_url { section.remove("api_url"); }
+    }
+    write_ini(&path, &data)
+}
+
+pub fn delete_profile(name: &str) -> Result<()> {
+    let path = credentials_path()
+        .context("Unable to resolve home directory")?;
+    let mut data = read_ini(&path);
+    data.remove(name);
+    write_ini(&path, &data)
+}
+
+pub fn get_active_profile() -> String {
+    // Env var takes precedence over config file
+    if let Ok(p) = std::env::var(ENV_PROFILE) {
+        let p = p.trim().to_string();
+        if !p.is_empty() {
+            return p;
+        }
+    }
+    config_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| {
+            s.lines()
+                .find_map(|line| {
+                    let line = line.trim();
+                    line.strip_prefix("active_profile")
+                        .and_then(|rest| rest.trim().strip_prefix('='))
+                        .map(|v| v.trim().trim_matches('"').to_string())
+                })
+        })
+        .unwrap_or_else(|| DEFAULT_PROFILE.to_string())
+}
+
+pub fn set_active_profile(name: &str) -> Result<()> {
+    let path = config_path()
+        .context("Unable to resolve home directory")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Read existing config, update or insert active_profile line
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut lines: Vec<String> = existing.lines().map(|l| l.to_string()).collect();
+    let new_line = format!("active_profile = \"{}\"", name);
+    let pos = lines.iter().position(|l| l.trim().starts_with("active_profile"));
+    match pos {
+        Some(i) => lines[i] = new_line,
+        None => lines.push(new_line),
+    }
+    std::fs::write(&path, lines.join("\n") + "\n")?;
+    Ok(())
+}
+
+/// Migrate legacy `~/.distri/config` (api_key, workspace_id, base_url keys) to
+/// the [default] profile in `~/.distri/credentials`, then remove those keys from config.
+pub fn migrate_legacy_config() -> Result<()> {
+    let config_path = match config_path() {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+    let creds_path = match credentials_path() {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+    // Only migrate if credentials file doesn't exist yet
+    if creds_path.exists() {
+        return Ok(());
+    }
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return Ok(()),
+    };
+    // Parse TOML-style config for legacy keys
+    let mut api_key: Option<String> = None;
+    let mut workspace_id: Option<String> = None;
+    let mut base_url: Option<String> = None;
+    let mut remaining_lines: Vec<String> = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("api_key") {
+            if let Some(v) = rest.trim().strip_prefix('=') {
+                api_key = Some(v.trim().trim_matches('"').to_string());
+                continue;
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix("workspace_id") {
+            if let Some(v) = rest.trim().strip_prefix('=') {
+                workspace_id = Some(v.trim().trim_matches('"').to_string());
+                continue;
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix("base_url") {
+            if let Some(v) = rest.trim().strip_prefix('=') {
+                base_url = Some(v.trim().trim_matches('"').to_string());
+                continue;
+            }
+        }
+        remaining_lines.push(line.to_string());
+    }
+    if api_key.is_some() || workspace_id.is_some() || base_url.is_some() {
+        let values = ProfileValues {
+            api_key,
+            workspace_id,
+            api_url: base_url,
+        };
+        save_profile(DEFAULT_PROFILE, &values)?;
+        // Rewrite config without the migrated keys
+        std::fs::write(&config_path, remaining_lines.join("\n") + "\n")?;
+    }
+    Ok(())
+}
+
+/// Build a DistriConfig by merging: env vars > active profile > defaults.
+/// Call this instead of DistriConfig::from_env() in the CLI.
+pub fn load_config_with_profile() -> distri_types::DistriConfig {
+    use distri_types::DistriConfig;
+    let profile_name = get_active_profile();
+    let profile = load_profile(&profile_name).unwrap_or_default().unwrap_or_default();
+
+    let env_api_key = std::env::var("DISTRI_API_KEY").ok().filter(|s| !s.is_empty());
+    let env_workspace_id = std::env::var("DISTRI_WORKSPACE_ID").ok().filter(|s| !s.is_empty());
+    let env_base_url = std::env::var("DISTRI_BASE_URL").ok().filter(|s| !s.is_empty());
+
+    let base_url = env_base_url
+        .or(profile.api_url)
+        .unwrap_or_else(|| DEFAULT_API_URL.to_string());
+    let api_key = env_api_key.or(profile.api_key);
+    let workspace_id = env_workspace_id.or(profile.workspace_id);
+
+    DistriConfig::new(base_url)
+        .with_maybe_api_key(api_key)
+        .with_maybe_workspace_id(workspace_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn with_temp_dir(f: impl FnOnce(&TempDir)) {
+        let dir = TempDir::new().unwrap();
+        f(&dir);
+    }
+
+    fn temp_creds_path(dir: &TempDir) -> PathBuf {
+        dir.path().join("credentials")
+    }
+
+    fn temp_config_path(dir: &TempDir) -> PathBuf {
+        dir.path().join("config")
+    }
+
+    // Helper: parse/serialize round-trip
+    #[test]
+    fn test_ini_round_trip() {
+        let input = "[default]\napi_key = dak_abc\nworkspace_id = 1234\n\n[local]\napi_url = http://localhost:8080/v1\n";
+        let data = parse_ini(input);
+        assert_eq!(data["default"]["api_key"], "dak_abc");
+        assert_eq!(data["local"]["api_url"], "http://localhost:8080/v1");
+        let out = serialize_ini(&data);
+        let reparsed = parse_ini(&out);
+        assert_eq!(data, reparsed);
+    }
+
+    #[test]
+    fn test_save_load_profile() {
+        with_temp_dir(|dir| {
+            let path = temp_creds_path(dir);
+            // Manually call write_ini via save_profile using overridden path
+            let mut data: IniData = BTreeMap::new();
+            let values = ProfileValues {
+                api_key: Some("dak_test".to_string()),
+                workspace_id: Some("ws-123".to_string()),
+                api_url: Some("https://api.distri.dev/v1".to_string()),
+            };
+            let section = data.entry("default".to_string()).or_default();
+            section.insert("api_key".to_string(), "dak_test".to_string());
+            section.insert("workspace_id".to_string(), "ws-123".to_string());
+            section.insert("api_url".to_string(), "https://api.distri.dev/v1".to_string());
+            write_ini(&path, &data).unwrap();
+            let loaded = read_ini(&path);
+            let profile = section_to_profile(&loaded["default"]);
+            assert_eq!(profile, values);
+        });
+    }
+
+    #[test]
+    fn test_merge_save_preserves_existing_keys() {
+        with_temp_dir(|dir| {
+            let path = temp_creds_path(dir);
+            // Write initial full profile
+            let mut data: IniData = BTreeMap::new();
+            let section = data.entry("default".to_string()).or_default();
+            section.insert("api_key".to_string(), "old_key".to_string());
+            section.insert("workspace_id".to_string(), "old_ws".to_string());
+            section.insert("api_url".to_string(), "https://api.distri.dev/v1".to_string());
+            write_ini(&path, &data).unwrap();
+
+            // Update only api_key by reading and merging
+            let mut existing = read_ini(&path);
+            let s = existing.entry("default".to_string()).or_default();
+            s.insert("api_key".to_string(), "new_key".to_string());
+            write_ini(&path, &existing).unwrap();
+
+            let result = read_ini(&path);
+            assert_eq!(result["default"]["api_key"], "new_key");
+            assert_eq!(result["default"]["workspace_id"], "old_ws"); // preserved
+            assert_eq!(result["default"]["api_url"], "https://api.distri.dev/v1"); // preserved
+        });
+    }
+
+    #[test]
+    fn test_delete_profile() {
+        with_temp_dir(|dir| {
+            let path = temp_creds_path(dir);
+            let mut data: IniData = BTreeMap::new();
+            data.entry("default".to_string()).or_default().insert("api_key".to_string(), "k".to_string());
+            data.entry("local".to_string()).or_default().insert("api_key".to_string(), "k2".to_string());
+            write_ini(&path, &data).unwrap();
+            let mut d = read_ini(&path);
+            d.remove("local");
+            write_ini(&path, &d).unwrap();
+            let result = read_ini(&path);
+            assert!(result.contains_key("default"));
+            assert!(!result.contains_key("local"));
+        });
+    }
+
+    #[test]
+    fn test_migrate_legacy_config() {
+        with_temp_dir(|dir| {
+            let config = temp_config_path(dir);
+            let creds = temp_creds_path(dir);
+            std::fs::write(&config, "api_key = \"dak_old\"\nworkspace_id = \"ws-old\"\n").unwrap();
+            // Run migration inline (can't use global paths in unit test, so test the logic directly)
+            let content = std::fs::read_to_string(&config).unwrap();
+            let mut api_key: Option<String> = None;
+            let mut workspace_id: Option<String> = None;
+            let mut remaining: Vec<String> = Vec::new();
+            for line in content.lines() {
+                let t = line.trim();
+                if let Some(rest) = t.strip_prefix("api_key") {
+                    if let Some(v) = rest.trim().strip_prefix('=') {
+                        api_key = Some(v.trim().trim_matches('"').to_string());
+                        continue;
+                    }
+                }
+                if let Some(rest) = t.strip_prefix("workspace_id") {
+                    if let Some(v) = rest.trim().strip_prefix('=') {
+                        workspace_id = Some(v.trim().trim_matches('"').to_string());
+                        continue;
+                    }
+                }
+                remaining.push(line.to_string());
+            }
+            assert_eq!(api_key.as_deref(), Some("dak_old"));
+            assert_eq!(workspace_id.as_deref(), Some("ws-old"));
+            // Write to creds
+            let mut data: IniData = BTreeMap::new();
+            let s = data.entry("default".to_string()).or_default();
+            s.insert("api_key".to_string(), api_key.unwrap());
+            s.insert("workspace_id".to_string(), workspace_id.unwrap());
+            write_ini(&creds, &data).unwrap();
+            std::fs::write(&config, remaining.join("\n") + "\n").unwrap();
+            // Verify
+            let migrated = read_ini(&creds);
+            assert_eq!(migrated["default"]["api_key"], "dak_old");
+            let new_config = std::fs::read_to_string(&config).unwrap();
+            assert!(!new_config.contains("api_key"));
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run tests (expect compile error — `with_maybe_api_key` doesn't exist yet)**
+
+```bash
+cd distri && cargo test -p distri-cli credentials 2>&1 | head -30
+```
+
+Expected: compile error about `with_maybe_api_key` / `with_maybe_workspace_id`.
+
+- [ ] **Step 3: Add `with_maybe_*` helpers to `DistriConfig` in `distri-types/src/client_config.rs`**
+
+Add after the existing `with_workspace_id` method:
+
+```rust
+/// Set the API key if Some.
+pub fn with_maybe_api_key(mut self, api_key: Option<String>) -> Self {
+    self.api_key = api_key;
+    self
+}
+
+/// Set the workspace ID if Some.
+pub fn with_maybe_workspace_id(mut self, workspace_id: Option<String>) -> Self {
+    self.workspace_id = workspace_id;
+    self
+}
+```
+
+- [ ] **Step 4: Add `credentials` module to `distri-cli/src/main.rs`**
+
+Add to the module declarations at the top of `main.rs`:
+
+```rust
+mod credentials;
+```
+
+- [ ] **Step 5: Run tests — expect them to pass**
+
+```bash
+cd distri && cargo test -p distri-cli credentials 2>&1
+```
+
+Expected: all `credentials::tests::*` pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd distri && git add distri-cli/src/credentials.rs distri-cli/src/main.rs distri-types/src/client_config.rs
+git commit -m "feat: add credentials.rs with INI profile I/O and DistriConfig helpers"
+```
+
+---
+
+### Task 2: Wire `load_config_with_profile()` into main.rs + run migration
+
+**Files:**
+- Modify: `distri/distri-cli/src/main.rs`
+
+- [ ] **Step 1: Replace `DistriConfig::from_env()` call in `main.rs`**
+
+In `main.rs`, find (around line 357):
+```rust
+let mut config = DistriConfig::from_env();
+```
+
+Replace with:
+```rust
+// Run one-time migration of legacy ~/.distri/config keys to ~/.distri/credentials
+let _ = crate::credentials::migrate_legacy_config();
+let mut config = crate::credentials::load_config_with_profile();
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd distri && cargo check -p distri-cli 2>&1 | grep "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Smoke test — running distri still loads config**
+
+```bash
+cd distri && cargo run -p distri-cli -- --help 2>&1 | head -5
+```
+
+Expected: help text printed without panic.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd distri && git add distri-cli/src/main.rs
+git commit -m "feat: wire load_config_with_profile into CLI startup with legacy migration"
+```
+
+---
+
+### Task 3: Replace `Commands::Config` with `Commands::Profile` in main.rs
+
+**Files:**
+- Modify: `distri/distri-cli/src/main.rs`
+
+- [ ] **Step 1: Remove `ConfigCommands` and add `ProfileCommands` enums**
+
+In `main.rs`, replace the `ConfigCommands` block:
+
+```rust
+// REMOVE this entire block:
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum ConfigCommands {
+    Set {
+        #[clap(help = "Config key (api_key, base_url, workspace_id)")]
+        key: String,
+        #[clap(help = "Value to set (empty clears the key)", num_args = 1..)]
+        value: Vec<String>,
+    },
+}
+```
+
+Add new enums:
+
+```rust
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum ProfileCommands {
+    /// List all profiles
+    List,
+    /// Set the active profile
+    Use {
+        #[clap(help = "Profile name")]
+        name: String,
+    },
+    /// Show profile values (active profile if no name given)
+    Show {
+        #[clap(help = "Profile name (defaults to active)")]
+        name: Option<String>,
+    },
+    /// Delete a profile
+    Delete {
+        #[clap(help = "Profile name")]
+        name: String,
+        #[clap(long, short, help = "Skip confirmation prompt")]
+        yes: bool,
+    },
+    /// Manage credential keys within a profile
+    Config {
+        #[clap(subcommand)]
+        command: ProfileConfigCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum ProfileConfigCommands {
+    /// Set one or more credential keys on a profile
+    Set {
+        #[clap(long, help = "Target profile (defaults to active)")]
+        profile: Option<String>,
+        #[clap(long, help = "API key")]
+        api_key: Option<String>,
+        #[clap(long, help = "Workspace ID (UUID)")]
+        workspace_id: Option<String>,
+        #[clap(long, help = "API URL")]
+        api_url: Option<String>,
+    },
+    /// Remove one or more credential keys from a profile
+    Unset {
+        #[clap(long, help = "Target profile (defaults to active)")]
+        profile: Option<String>,
+        #[clap(long, help = "Remove api_key")]
+        api_key: bool,
+        #[clap(long, help = "Remove workspace_id")]
+        workspace_id: bool,
+        #[clap(long, help = "Remove api_url")]
+        api_url: bool,
+    },
+}
+```
+
+- [ ] **Step 2: Replace `Commands::Config` variant with `Commands::Profile`, add `--profile` to `Login`**
+
+In the `Commands` enum, replace:
+```rust
+/// Manage local client configuration
+Config {
+    #[clap(subcommand)]
+    command: ConfigCommands,
+},
+```
+With:
+```rust
+/// Manage authentication profiles
+Profile {
+    #[clap(subcommand)]
+    command: ProfileCommands,
+},
+```
+
+And update `Commands::Login`:
+```rust
+/// Login to Distri Cloud and configure workspace
+Login {
+    #[clap(long, help = "Email address")]
+    email: Option<String>,
+    #[clap(long, help = "Skip workspace selection (use default)")]
+    skip_workspace: bool,
+    #[clap(long, help = "Profile name to save credentials into (default: \"default\")")]
+    profile: Option<String>,
+},
+```
+
+- [ ] **Step 3: Update the `match command` block in `main.rs`**
+
+Find the `Commands::Config` match arm:
+```rust
+Commands::Config { command } => {
+    handle_config_command(command)?;
+}
+```
+Replace with:
+```rust
+Commands::Profile { command } => {
+    handle_profile_command(command)?;
+}
+```
+
+Find the `Commands::Login` match arm and add `profile`:
+```rust
+Commands::Login { email, skip_workspace, profile } => {
+    login::handle_login_command(email, skip_workspace, profile).await?;
+}
+```
+
+- [ ] **Step 4: Update imports in `main.rs`** — remove `handle_config_command` from the `commands::` import, add `handle_profile_command`:
+
+```rust
+use commands::{
+    handle_connections_command, handle_profile_command, handle_prompts_command,
+    handle_secrets_command, handle_skills_command, handle_workflow_command, push_file,
+};
+```
+
+- [ ] **Step 5: Verify compile (will fail until handle_profile_command exists)**
+
+```bash
+cd distri && cargo check -p distri-cli 2>&1 | grep "^error" | head -10
+```
+
+Expected: error about `handle_profile_command` not found — that's correct, implement it next.
+
+---
+
+### Task 4: Implement `handle_profile_command` in `commands.rs`
+
+**Files:**
+- Modify: `distri/distri-cli/src/commands.rs`
+
+- [ ] **Step 1: Remove `handle_config_command` and add `handle_profile_command`**
+
+Remove the old import at the top of `commands.rs`:
+```rust
+// REMOVE:
+use crate::config::set_client_config_value;
+use crate::{
+    ConfigCommands, ...
+};
+```
+
+Replace with:
+```rust
+use crate::{
+    ConnectionsCommands, ProfileCommands, ProfileConfigCommands, PromptsCommands,
+    SecretsCommands, SkillsCommands, WorkflowCommands, COLOR_BRIGHT_GREEN, COLOR_GRAY, COLOR_RESET,
+};
+```
+
+Remove `handle_config_command` entirely.
+
+Add at the end of `commands.rs`:
+
+```rust
+fn mask_api_key(key: &str) -> String {
+    if key.len() > 14 {
+        format!("{}...{}", &key[..10], &key[key.len() - 4..])
+    } else {
+        "***".to_string()
+    }
+}
+
+pub fn handle_profile_command(command: ProfileCommands) -> anyhow::Result<()> {
+    use crate::credentials::{
+        delete_profile, get_active_profile, list_profiles, load_profile, save_profile,
+        set_active_profile, unset_profile_keys, ProfileValues,
+    };
+
+    match command {
+        ProfileCommands::List => {
+            let active = get_active_profile();
+            let profiles = list_profiles()?;
+            if profiles.is_empty() {
+                println!("No profiles found. Run `distri login` or `distri profile config set` to create one.");
+                return Ok(());
+            }
+            for (name, values) in &profiles {
+                let marker = if name == &active { "*" } else { " " };
+                let key_str = values
+                    .api_key
+                    .as_deref()
+                    .map(mask_api_key)
+                    .unwrap_or_else(|| "(none)".to_string());
+                let ws_str = values
+                    .workspace_id
+                    .as_deref()
+                    .unwrap_or("(none)");
+                let url_str = values
+                    .api_url
+                    .as_deref()
+                    .unwrap_or("https://api.distri.dev/v1");
+                println!(
+                    "{} {:<12}  api_key={:<20}  workspace={:<36}  url={}",
+                    marker, name, key_str, ws_str, url_str
+                );
+            }
+        }
+
+        ProfileCommands::Use { name } => {
+            let profiles = list_profiles()?;
+            let exists = profiles.iter().any(|(n, _)| n == &name);
+            if !exists {
+                anyhow::bail!(
+                    "Profile '{}' not found. Run `distri profile list` to see available profiles.",
+                    name
+                );
+            }
+            set_active_profile(&name)?;
+            println!("Active profile set to '{}'.", name);
+        }
+
+        ProfileCommands::Show { name } => {
+            let profile_name = name.unwrap_or_else(get_active_profile);
+            match load_profile(&profile_name)? {
+                None => {
+                    anyhow::bail!(
+                        "Profile '{}' not found. Run `distri profile list` to see available profiles.",
+                        profile_name
+                    );
+                }
+                Some(values) => {
+                    println!("Profile: {}", profile_name);
+                    println!(
+                        "  api_key     = {}",
+                        values.api_key.as_deref().map(mask_api_key).unwrap_or_else(|| "(not set)".to_string())
+                    );
+                    println!(
+                        "  workspace_id = {}",
+                        values.workspace_id.as_deref().unwrap_or("(not set)")
+                    );
+                    println!(
+                        "  api_url     = {}",
+                        values.api_url.as_deref().unwrap_or("https://api.distri.dev/v1 (default)")
+                    );
+                }
+            }
+        }
+
+        ProfileCommands::Delete { name, yes } => {
+            let active = get_active_profile();
+            if name == active {
+                anyhow::bail!(
+                    "Cannot delete the active profile '{}'. Run `distri profile use <other>` first.",
+                    name
+                );
+            }
+            if !yes {
+                print!("Delete profile '{}'? [y/N] ", name);
+                std::io::stdout().flush().ok();
+                let mut input = String::new();
+                std::io::stdin().read_line(&mut input).ok();
+                if !input.trim().eq_ignore_ascii_case("y") {
+                    println!("Aborted.");
+                    return Ok(());
+                }
+            }
+            delete_profile(&name)?;
+            println!("Profile '{}' deleted.", name);
+        }
+
+        ProfileCommands::Config { command } => match command {
+            ProfileConfigCommands::Set {
+                profile,
+                api_key,
+                workspace_id,
+                api_url,
+            } => {
+                if api_key.is_none() && workspace_id.is_none() && api_url.is_none() {
+                    anyhow::bail!(
+                        "At least one of --api-key, --workspace-id, or --api-url is required."
+                    );
+                }
+                if let Some(ref ws) = workspace_id {
+                    uuid::Uuid::parse_str(ws).with_context(|| {
+                        format!("Invalid workspace_id: '{}' is not a valid UUID", ws)
+                    })?;
+                }
+                let profile_name = profile.unwrap_or_else(get_active_profile);
+                let values = ProfileValues {
+                    api_key,
+                    workspace_id,
+                    api_url,
+                };
+                save_profile(&profile_name, &values)?;
+                println!("Updated profile '{}'.", profile_name);
+            }
+
+            ProfileConfigCommands::Unset {
+                profile,
+                api_key,
+                workspace_id,
+                api_url,
+            } => {
+                if !api_key && !workspace_id && !api_url {
+                    anyhow::bail!(
+                        "At least one of --api-key, --workspace-id, or --api-url is required."
+                    );
+                }
+                let profile_name = profile.unwrap_or_else(get_active_profile);
+                unset_profile_keys(&profile_name, api_key, workspace_id, api_url)?;
+                println!("Unset keys from profile '{}'.", profile_name);
+            }
+        },
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add missing import for `flush` in commands.rs**
+
+Ensure `use std::io::Write;` is already present at the top (it is, from existing code).
+
+- [ ] **Step 3: Verify compile**
+
+```bash
+cd distri && cargo check -p distri-cli 2>&1 | grep "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd distri && git add distri-cli/src/commands.rs distri-cli/src/main.rs
+git commit -m "feat: add profile list/use/show/delete/config commands"
+```
+
+---
+
+### Task 5: Update `login.rs` to save to credentials file with `--profile` support
+
+**Files:**
+- Modify: `distri/distri-cli/src/login.rs`
+
+- [ ] **Step 1: Update `handle_login_command` signature and `save_config` call**
+
+In `login.rs`, change the function signature:
+```rust
+pub async fn handle_login_command(
+    _email: Option<String>,
+    _skip_workspace: bool,
+    profile: Option<String>,
+) -> Result<()> {
+```
+
+Change the `save_config` call near the end:
+```rust
+// Replace:
+save_config(&api_key, &workspace_id)?;
+
+// With:
+let profile_name = profile.as_deref().unwrap_or("default");
+save_credentials(profile_name, &api_key, &workspace_id, &login_url_response.login_url)?;
+```
+
+Add the print line below it to show which profile was saved:
+```rust
+println!("\n✓ Successfully authenticated!");
+println!("  Profile:      {}", profile_name);
+println!(
+    "  API Key:      {}...{}",
+    &api_key[..10],
+    &api_key[api_key.len() - 4..]
+);
+println!("  Workspace ID: {}", workspace_id);
+println!("\nYou can now use 'distri'. Run 'distri -h' for help");
+```
+
+- [ ] **Step 2: Replace `save_config` with `save_credentials`**
+
+Remove the old `save_config` and `load_config_toml` functions entirely from `login.rs`.
+
+Add at the bottom of `login.rs`:
+
+```rust
+fn save_credentials(
+    profile_name: &str,
+    api_key: &str,
+    workspace_id: &str,
+    login_url: &str,
+) -> Result<()> {
+    // Extract the base api_url from the login_url (strip the /cli-login path)
+    let api_url = login_url
+        .split("/cli-login")
+        .next()
+        .unwrap_or("https://api.distri.dev")
+        .trim_end_matches('/')
+        .to_string()
+        + "/v1";
+
+    let values = crate::credentials::ProfileValues {
+        api_key: Some(api_key.to_string()),
+        workspace_id: Some(workspace_id.to_string()),
+        api_url: Some(api_url),
+    };
+    crate::credentials::save_profile(profile_name, &values)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Remove unused imports in `login.rs`**
+
+Remove these no-longer-needed imports:
+```rust
+// REMOVE:
+use std::path::PathBuf;
+use distri::{Distri, DistriConfig};
+// Keep:
+use distri::Distri;
+```
+
+(Keep `DistriConfig` only if still used for `Distri::from_env()`.)
+
+Check what `Distri::from_env()` requires — if it uses `DistriConfig`, keep both. The login command needs a client to call `get_login_url`, which uses `Distri::from_env()`:
+
+```rust
+let client = Distri::from_env();
+```
+
+`Distri::from_env()` will now call `DistriConfig::from_env()` (unchanged for the SDK). This is fine — login just needs the base_url from the server to get the login page URL, which works with or without credentials.
+
+- [ ] **Step 4: Verify compile**
+
+```bash
+cd distri && cargo check -p distri-cli 2>&1 | grep "^error"
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd distri && git add distri-cli/src/login.rs
+git commit -m "feat: login saves to credentials profile, add --profile flag"
+```
+
+---
+
+### Task 6: Remove `set_client_config_value` / `load_client_config_value` from config.rs
+
+**Files:**
+- Modify: `distri/distri-cli/src/config.rs`
+
+- [ ] **Step 1: Delete the two dead functions from `config.rs`**
+
+Remove `set_client_config_value` (lines 56–97) and `load_client_config_value` (lines 99–108) entirely from `config.rs`.
+
+The remaining functions to keep: `resolve_workspace`, `get_last_model_file`, `save_last_model`, `load_last_model`, `normalize_optional`, `normalize_base_url`.
+
+- [ ] **Step 2: Verify compile with no dead-code warnings**
+
+```bash
+cd distri && cargo check -p distri-cli 2>&1 | grep -E "^error|unused import"
+```
+
+Expected: no errors, no unused import warnings for the removed functions.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cd distri && cargo test -p distri-cli 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd distri && git add distri-cli/src/config.rs
+git commit -m "chore: remove deprecated set_client_config_value, all config now via profile"
+```
+
+---
+
+### Task 7: Final verification
+
+- [ ] **Step 1: Run clippy**
+
+```bash
+cd distri && cargo clippy -p distri-cli -- -D warnings 2>&1 | head -30
+```
+
+Fix any warnings before proceeding.
+
+- [ ] **Step 2: Run cargo fmt**
+
+```bash
+cd distri && cargo fmt -p distri-cli
+```
+
+- [ ] **Step 3: Manual smoke test of profile commands**
+
+```bash
+cd distri && cargo run -p distri-cli -- profile list
+# Expected: "No profiles found. Run `distri login` or `distri profile config set`..."
+
+cargo run -p distri-cli -- profile config set --api-key dak_test123456 --workspace-id "00000000-0000-0000-0000-000000000001" --api-url "http://localhost:8080/v1"
+# Expected: "Updated profile 'default'."
+
+cargo run -p distri-cli -- profile list
+# Expected: "* default   api_key=dak_test123...456  workspace=00000000-...  url=http://localhost:8080/v1"
+
+cargo run -p distri-cli -- profile config set --api-key dak_other1234 --profile staging
+# Expected: "Updated profile 'staging'."
+
+cargo run -p distri-cli -- profile use staging
+# Expected: "Active profile set to 'staging'."
+
+cargo run -p distri-cli -- profile show
+# Expected: shows staging profile values
+
+cargo run -p distri-cli -- profile use default
+cargo run -p distri-cli -- profile delete staging --yes
+# Expected: "Profile 'staging' deleted."
+```
+
+- [ ] **Step 4: Verify `distri config` no longer exists**
+
+```bash
+cd distri && cargo run -p distri-cli -- config set api_key foo 2>&1
+```
+
+Expected: "error: unrecognized subcommand 'config'"
+
+- [ ] **Step 5: Final commit**
+
+```bash
+cd distri && cargo fmt -p distri-cli
+git add -p
+git commit -m "chore: fmt and clippy fixes for cli profiles feature"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ `~/.distri/credentials` INI format — Task 1
+- ✅ `~/.distri/config` active_profile — Task 1 (`get_active_profile`, `set_active_profile`)
+- ✅ Legacy migration — Task 1 (`migrate_legacy_config`) + Task 2 (wired in main)
+- ✅ `DistriConfig` precedence (env > profile > defaults) — Task 1 (`load_config_with_profile`)
+- ✅ `DISTRI_PROFILE` env var — Task 1 (`get_active_profile`)
+- ✅ `distri profile list` — Task 4
+- ✅ `distri profile use` — Task 4
+- ✅ `distri profile show` — Task 4
+- ✅ `distri profile delete` — Task 4
+- ✅ `distri profile config set` (multi-key, merge) — Task 4
+- ✅ `distri profile config unset` — Task 4
+- ✅ `distri login --profile` — Task 5
+- ✅ `distri config` removed — Task 6
+- ✅ Error messages per spec — Task 4
+
+**Placeholder scan:** No TBDs found.
+
+**Type consistency:** `ProfileValues`, `save_profile`, `load_profile`, `unset_profile_keys` defined in Task 1 and used consistently in Tasks 4 and 5.

--- a/docs/superpowers/specs/2026-04-07-cli-profiles-design.md
+++ b/docs/superpowers/specs/2026-04-07-cli-profiles-design.md
@@ -1,0 +1,167 @@
+# CLI Profiles Design
+
+**Date:** 2026-04-07  
+**Status:** Approved
+
+## Overview
+
+Replace the single `~/.distri/config` credential store with a named-profile system modelled on AWS CLI. Each profile holds a fixed set of Distri environment variables (api_url, api_key, workspace_id). The active profile is tracked in `~/.distri/config`. `distri config set` is removed; all credential management moves under `distri profile`.
+
+---
+
+## File Format & Storage
+
+### `~/.distri/credentials` (new)
+
+INI format. One section per profile. Created by `distri login` or `distri profile config set`.
+
+```ini
+[default]
+api_key = dak_xxx
+workspace_id = 91e3e4e4-0706-4aa8-b6e3-ba64e712fa96
+api_url = https://api.distri.dev/v1
+
+[local]
+api_key = dak_yyy
+workspace_id = abc-123
+api_url = http://localhost:8080/v1
+```
+
+Supported keys per profile: `api_key`, `workspace_id`, `api_url`. Any key may be omitted; omitted keys fall through to built-in defaults.
+
+### `~/.distri/config` (updated)
+
+Tracks the active profile name only. All credential keys removed.
+
+```toml
+active_profile = "local"
+```
+
+If the file has no `active_profile`, `"default"` is used.
+
+### Migration
+
+On first run after upgrade, if `~/.distri/credentials` does not exist and `~/.distri/config` contains `api_key` or `workspace_id`, those values are silently migrated into the `[default]` section of `~/.distri/credentials` and removed from `~/.distri/config`.
+
+---
+
+## Config Loading (`DistriConfig`)
+
+**Precedence (highest → lowest):**
+
+1. `DISTRI_API_KEY`, `DISTRI_BASE_URL`, `DISTRI_WORKSPACE_ID` env vars
+2. Profile selected by `DISTRI_PROFILE` env var (overrides active_profile)
+3. Profile named by `active_profile` in `~/.distri/config`
+4. `[default]` profile in `~/.distri/credentials`
+5. Built-in defaults (`api_url = https://api.distri.dev/v1`, others None)
+
+**New helpers on `DistriConfig`:**
+
+- `DistriConfig::credentials_path() -> Result<PathBuf>` — resolves `~/.distri/credentials`
+- `DistriConfig::active_profile() -> String` — reads from env or config file, returns `"default"` as fallback
+- `DistriConfig::load_profile(name: &str) -> Result<ProfileValues>` — parses INI, returns the named section
+
+INI parsing is done with the `configparser` crate (already available in Rust ecosystem as `configparser = "3"`). No manual parsing.
+
+`DistriConfig` gains no new public fields — `base_url`, `api_key`, `workspace_id` are still the resolved values after applying precedence.
+
+---
+
+## CLI Commands
+
+`distri config` subcommand is **removed**. All credential management is under `distri profile`.
+
+### `distri login [--profile <name>]`
+
+- Runs OAuth browser flow (unchanged)
+- Saves `api_key`, `workspace_id`, and `api_url` (from server response) to the named profile in `~/.distri/credentials`
+- Default profile name: `"default"`
+- Does **not** change `active_profile`
+
+### `distri profile list`
+
+Lists all profiles from `~/.distri/credentials`. Marks the active profile with `*`. Shows masked api_key (`dak_xxx...xxxx`) and workspace_id.
+
+```
+* default   api_key=dak_2Mu...fShB  workspace=91e3e4e4  url=https://api.distri.dev/v1
+  local     api_key=dak_abc...1234  workspace=abc-123   url=http://localhost:8080/v1
+```
+
+### `distri profile use <name>`
+
+Writes `active_profile = "<name>"` to `~/.distri/config`. Errors if profile does not exist in credentials file.
+
+### `distri profile show [<name>]`
+
+Prints all keys for the active (or named) profile. api_key masked.
+
+### `distri profile delete <name>`
+
+Removes the named section from `~/.distri/credentials`. Errors if the profile is currently active (user must switch first).
+
+### `distri profile config set [--profile <name>] [--api-key <val>] [--workspace-id <val>] [--api-url <val>]`
+
+Sets one or more keys on the active (or named) profile. Creates the profile section if it doesn't exist. At least one key flag required.
+
+```bash
+distri profile config set --api-key dak_xxx --workspace-id abc-123 --api-url http://localhost:8080/v1
+distri profile config set --api-key dak_new          # update single key
+distri profile config set --api-key dak_x --profile local  # target specific profile
+```
+
+### `distri profile config unset [--profile <name>] [--api-key] [--workspace-id] [--api-url]`
+
+Removes one or more keys from the active (or named) profile. Key flags are boolean (no value). At least one key flag required.
+
+```bash
+distri profile config unset --api-url --workspace-id
+```
+
+---
+
+## Credentials File I/O
+
+A new module `distri-cli/src/credentials.rs` owns all reads/writes to `~/.distri/credentials`:
+
+```rust
+pub struct ProfileValues {
+    pub api_key: Option<String>,
+    pub workspace_id: Option<String>,
+    pub api_url: Option<String>,
+}
+
+pub fn list_profiles() -> Result<Vec<(String, ProfileValues)>>
+pub fn load_profile(name: &str) -> Result<Option<ProfileValues>>
+pub fn save_profile(name: &str, values: &ProfileValues) -> Result<()>   // merges, preserves other keys
+pub fn delete_profile(name: &str) -> Result<()>
+pub fn set_active_profile(name: &str) -> Result<()>
+pub fn get_active_profile() -> String
+pub fn migrate_legacy_config() -> Result<()>
+```
+
+The `save_profile` function **merges** — it only updates the keys provided and leaves others untouched. This is critical for `profile config set` updating a single key without clobbering others.
+
+---
+
+## Error Handling
+
+- `distri profile use <nonexistent>` → clear error: "Profile 'foo' not found. Run `distri profile list` to see available profiles."
+- `distri profile delete <active>` → error: "Cannot delete the active profile. Run `distri profile use <other>` first."
+- `distri profile config set` with no key flags → clap validation error before execution.
+- Missing `~/.distri/credentials` → treated as empty (no profiles), not an error.
+
+---
+
+## Testing
+
+- Unit tests in `credentials.rs` covering: save/load round-trip, merge behavior, list, delete, migration
+- Integration: `distri profile list` on empty credentials prints helpful empty state message
+- No store/DB tests needed — pure file I/O
+
+---
+
+## Out of Scope
+
+- Profile inheritance (one profile extending another)
+- Encrypting credentials at rest
+- Per-command `--profile` flag (only `profile config set/unset` support it; `--profile` on other commands is a future addition)


### PR DESCRIPTION
## Summary

- Replaces flat `~/.distri/config` credential storage with AWS-style INI profiles in `~/.distri/credentials`
- Adds `distri profile` subcommand with `list`, `use`, `show`, `delete`, and `config set/unset`
- `distri login --profile <name>` saves credentials to a named profile (default: `"default"`)
- `distri config set` removed — all credential management now under `distri profile`
- One-time silent migration of existing `~/.distri/config` keys into the `[default]` profile on first run
- Active profile overridable via `DISTRI_PROFILE` env var

## Usage

```bash
distri login                                          # saves to "default" profile
distri login --profile staging                        # saves to "staging" profile
distri profile config set --api-key dak_x --api-url http://localhost:8080/v1
distri profile list                                   # shows all profiles, marks active with *
distri profile use staging                            # switch active profile
distri profile show                                   # show active profile values
distri profile delete staging --yes
```

## Test Plan
- [ ] `cargo test -p distri-cli` — 24 tests pass
- [ ] `distri profile list` on fresh install shows empty state message
- [ ] `distri login` saves to `~/.distri/credentials` under `[default]`
- [ ] `distri profile use <nonexistent>` shows clear error
- [ ] `distri profile delete <active>` blocked with clear error
- [ ] Legacy `~/.distri/config` with `api_key`/`workspace_id` is migrated automatically
- [ ] `DISTRI_PROFILE=staging distri profile show` respects env override

🤖 Generated with [Claude Code](https://claude.com/claude-code)