### PR TITLE
Add structured input/output support for workflows and renderers

### DIFF
--- a/distri-formatter/src/lib.rs
+++ b/distri-formatter/src/lib.rs
@@ -150,6 +150,23 @@ pub trait SurfaceRenderer: Send + Sync {
     fn supports_rich_text(&self) -> bool;
     fn max_message_length(&self) -> Option<usize>;
 
+    // --- Structured content ---
+    /// Structured content rendering hook for downstream crates.
+    ///
+    /// Receives the tool name (e.g. `render_card`, `ask_follow_up`) and its
+    /// JSON input. Downstream crates override this to produce channel-specific
+    /// rich output (inline keyboards, interactive messages, etc.).
+    ///
+    /// Returns `RendererOutput::None` by default — plain-text surfaces ignore
+    /// structured content and let the agent's text response serve as fallback.
+    fn render_structured(
+        &mut self,
+        _tool_name: &str,
+        _data: &serde_json::Value,
+    ) -> RendererOutput {
+        RendererOutput::None
+    }
+
     // --- Output ---
     /// Take any pending output. Returns `RendererOutput::None` if nothing is ready.
     fn take_output(&mut self) -> RendererOutput;

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -192,8 +192,18 @@ impl Distri {
     }
 
     pub async fn register_agent(&self, definition: &StandardDefinition) -> Result<(), ClientError> {
+        let config =
+            distri_types::configuration::AgentConfig::StandardAgent(definition.clone());
+        self.register_agent_config(&config).await
+    }
+
+    /// Register any agent type (standard or workflow) from a typed `AgentConfig`.
+    pub async fn register_agent_config(
+        &self,
+        config: &distri_types::configuration::AgentConfig,
+    ) -> Result<(), ClientError> {
         let create_url = format!("{}/agents", self.base_url);
-        let resp = self.http.post(&create_url).json(definition).send().await?;
+        let resp = self.http.post(&create_url).json(config).send().await?;
         if resp.status().is_success() {
             return Ok(());
         }

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -14,7 +14,23 @@ use crate::{
 use async_trait::async_trait;
 use distri_types::configuration::WorkflowAgentDefinition;
 use distri_workflow::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+/// Typed input envelope for workflow agent invocation.
+///
+/// Workflow-control fields (entry_point) are parsed explicitly;
+/// everything else is forwarded as the workflow's user input via `#[serde(flatten)]`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkflowInput {
+    /// Optional entry point ID to start the workflow from a specific step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry_point: Option<String>,
+
+    /// All remaining fields are forwarded as workflow user input.
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
 
 /// A workflow-based agent that executes a workflow DAG.
 #[derive(Clone, Debug)]
@@ -389,26 +405,33 @@ impl WorkflowAgent {
                 AgentError::Execution(format!("Invalid workflow definition: {}", e))
             })?;
 
-        // Extract input from message (first text part as JSON, or empty)
-        let input = message
+        // Parse typed input from message (first text part as JSON, or defaults)
+        let workflow_input: WorkflowInput = message
             .parts
             .iter()
             .find_map(|p| {
                 if let distri_types::Part::Text(text) = p {
-                    serde_json::from_str::<serde_json::Value>(text).ok()
+                    serde_json::from_str::<WorkflowInput>(text).ok()
                 } else {
                     None
                 }
             })
-            .unwrap_or(serde_json::json!({}));
+            .unwrap_or_default();
 
         // Save user message to thread (like StandardAgent does)
         context.save_message(&message).await;
 
-        // Validate and merge input
+        // Validate and merge the user data (everything except workflow control fields)
         workflow = workflow
-            .with_input(input.clone())
+            .with_input(workflow_input.data)
             .map_err(|e| AgentError::Validation(e))?;
+
+        // Apply entry point if specified
+        if let Some(entry_id) = workflow_input.entry_point {
+            workflow = workflow
+                .apply_entry_point(&entry_id)
+                .map_err(|e| AgentError::Validation(e))?;
+        }
 
         // Populate env namespace from executor context env vars
         if let Some(ctx_obj) = workflow.context.as_object_mut() {


### PR DESCRIPTION
## Summary
This PR enhances the workflow agent and renderer infrastructure to support structured inputs and outputs, enabling better control flow and rich content rendering across different communication channels.

## Key Changes

### Workflow Agent Input Handling
- **New `WorkflowInput` struct**: Introduces a typed envelope for workflow invocation that separates workflow-control fields (like `entry_point`) from user data
  - `entry_point`: Optional field to start workflow execution from a specific step
  - `data`: Flattened user input forwarded to the workflow
- **Entry point support**: Workflows can now be resumed or started from a specific step via the `apply_entry_point()` method
- **Improved parsing**: Input is now deserialized as `WorkflowInput` instead of raw JSON, with proper defaults

### Renderer Structured Content Hook
- **New `render_structured()` method**: Adds an extension point in `SurfaceRenderer` trait for downstream crates to handle structured content
  - Receives tool name (e.g., `render_card`, `ask_follow_up`) and JSON data
  - Enables channel-specific rich output (inline keyboards, interactive messages, etc.)
  - Default implementation returns `RendererOutput::None` for backward compatibility with plain-text surfaces

### Client Agent Registration
- **Unified registration**: Refactored `register_agent()` to use a new `register_agent_config()` method
- **Type flexibility**: New method accepts any `AgentConfig` type (standard or workflow), improving extensibility
- **Cleaner API**: Reduces code duplication and provides a single path for agent registration

## Implementation Details
- The `WorkflowInput` struct uses `#[serde(flatten)]` to forward all non-control fields as workflow user input
- Entry point application is conditional and only applied if explicitly specified
- The renderer hook maintains backward compatibility by defaulting to `RendererOutput::None`

https://claude.ai/code/session_01VjUftErCokEtnABQVS13UN