### PR TITLE
Add Alibaba Cloud (DashScope) LLM provider support

### DIFF
--- a/distri-types/src/agent.rs
+++ b/distri-types/src/agent.rs
@@ -894,6 +894,12 @@ pub enum ModelProvider {
         api_key: Option<String>,
         project_id: Option<String>,
     },
+    #[serde(rename = "alibaba_cloud")]
+    AlibabaCloud {
+        #[serde(default = "ModelProvider::alibaba_cloud_base_url")]
+        base_url: String,
+        api_key: Option<String>,
+    },
 }
 /// Defines the secret requirements for a provider
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1014,6 +1020,10 @@ impl ModelProvider {
         "2024-06-01".to_string()
     }
 
+    pub fn alibaba_cloud_base_url() -> String {
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1".to_string()
+    }
+
     /// Returns the provider type enum for this provider.
     pub fn provider_type(&self) -> crate::models::ProviderType {
         match self {
@@ -1027,6 +1037,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => crate::models::ProviderType::AzureAiFoundry,
             ModelProvider::AwsBedrock { .. } => crate::models::ProviderType::AwsBedrock,
             ModelProvider::GoogleVertex { .. } => crate::models::ProviderType::GoogleVertex,
+            ModelProvider::AlibabaCloud { .. } => crate::models::ProviderType::AlibabaCloud,
         }
     }
 
@@ -1041,6 +1052,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => "azure_ai_foundry",
             ModelProvider::AwsBedrock { .. } => "aws_bedrock",
             ModelProvider::GoogleVertex { .. } => "google_vertex",
+            ModelProvider::AlibabaCloud { .. } => "alibaba_cloud",
         }
     }
 
@@ -1097,6 +1109,13 @@ impl ModelProvider {
                     vec!["GOOGLE_VERTEX_API_KEY"]
                 }
             }
+            ModelProvider::AlibabaCloud { api_key, .. } => {
+                if api_key.is_some() {
+                    vec![]
+                } else {
+                    vec!["DASHSCOPE_API_KEY"]
+                }
+            }
         }
     }
 
@@ -1136,6 +1155,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => "Azure AI Foundry",
             ModelProvider::AwsBedrock { .. } => "AWS Bedrock",
             ModelProvider::GoogleVertex { .. } => "Google Vertex AI",
+            ModelProvider::AlibabaCloud { .. } => "Alibaba Cloud",
         }
     }
 
@@ -1151,6 +1171,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => "azure.ai.inference",
             ModelProvider::AwsBedrock { .. } => "aws.bedrock",
             ModelProvider::GoogleVertex { .. } => "gcp.vertex_ai",
+            ModelProvider::AlibabaCloud { .. } => "alibaba_cloud",
         }
     }
 }
@@ -1247,6 +1268,10 @@ impl ModelSettings {
                 base_url: String::new(),
                 api_key: None,
                 project_id: None,
+            },
+            "alibaba_cloud" => ModelProvider::AlibabaCloud {
+                base_url: ModelProvider::alibaba_cloud_base_url(),
+                api_key: None,
             },
             _ if provider_str.starts_with("custom_") => ModelProvider::OpenAICompatible {
                 base_url: String::new(),

--- a/distri-types/src/default_models.json
+++ b/distri-types/src/default_models.json
@@ -752,6 +752,45 @@
         }
       ],
       "models": []
+    },
+    {
+      "id": "alibaba_cloud",
+      "label": "Alibaba Cloud",
+      "keys": [
+        {
+          "key": "DASHSCOPE_API_KEY",
+          "label": "API key",
+          "placeholder": "sk-...",
+          "required": true,
+          "sensitive": true
+        }
+      ],
+      "models": [
+        {
+          "id": "qwen3.6-plus",
+          "name": "Qwen3.6 Plus",
+          "capability": "completion",
+          "context_window": 1000000,
+          "pricing": {
+            "type": "completion",
+            "input": 0.276,
+            "output": 1.651,
+            "cached_input": 0.028
+          }
+        },
+        {
+          "id": "qwen3.5-35b-a3b",
+          "name": "Qwen3.5 35B A3B",
+          "capability": "completion",
+          "context_window": 262144,
+          "pricing": {
+            "type": "completion",
+            "input": 0.16,
+            "output": 1.30,
+            "cached_input": 0.016
+          }
+        }
+      ]
     }
   ]
 }

--- a/distri-types/src/models.rs
+++ b/distri-types/src/models.rs
@@ -16,6 +16,7 @@ pub enum ProviderType {
     AzureAiFoundry,
     AwsBedrock,
     GoogleVertex,
+    AlibabaCloud,
     #[serde(rename = "elevenlabs")]
     ElevenLabs,
     /// User-defined provider (LangDB-compatible / OpenAI-compatible)
@@ -33,6 +34,7 @@ impl ProviderType {
             Self::AzureAiFoundry => "azure_ai_foundry",
             Self::AwsBedrock => "aws_bedrock",
             Self::GoogleVertex => "google_vertex",
+            Self::AlibabaCloud => "alibaba_cloud",
             Self::ElevenLabs => "elevenlabs",
             Self::Custom(id) => id.as_str(),
         }
@@ -47,6 +49,7 @@ impl ProviderType {
             Self::AzureAiFoundry => "Azure AI Foundry",
             Self::AwsBedrock => "AWS Bedrock",
             Self::GoogleVertex => "Google Vertex AI",
+            Self::AlibabaCloud => "Alibaba Cloud",
             Self::ElevenLabs => "ElevenLabs",
             Self::Custom(id) => id.as_str(),
         }
@@ -61,6 +64,7 @@ impl ProviderType {
             "azure_ai_foundry" => Self::AzureAiFoundry,
             "aws_bedrock" => Self::AwsBedrock,
             "google_vertex" => Self::GoogleVertex,
+            "alibaba_cloud" => Self::AlibabaCloud,
             "elevenlabs" => Self::ElevenLabs,
             other => Self::Custom(other.to_string()),
         }

--- a/server/distri-core/model_pricing.json
+++ b/server/distri-core/model_pricing.json
@@ -18,7 +18,9 @@
     "gemini-2.5-flash": { "input": 0.15, "output": 0.60, "cached_input": 0.0375 },
     "gemini-2.0-flash": { "input": 0.10, "output": 0.40, "cached_input": 0.025 },
     "deepseek-chat": { "input": 0.27, "output": 1.10, "cached_input": 0.07 },
-    "deepseek-reasoner": { "input": 0.55, "output": 2.19, "cached_input": 0.14 }
+    "deepseek-reasoner": { "input": 0.55, "output": 2.19, "cached_input": 0.14 },
+    "qwen3.6-plus": { "input": 0.276, "output": 1.651, "cached_input": 0.028 },
+    "qwen3.5-35b-a3b": { "input": 0.16, "output": 1.30, "cached_input": 0.016 }
   },
   "_comment": "Prices in USD per 1M tokens. cached_input is the price for cache-read input tokens."
 }

--- a/server/distri-core/src/llm.rs
+++ b/server/distri-core/src/llm.rs
@@ -1551,7 +1551,8 @@ pub fn create_llm_executor(
         | ModelProvider::Gemini { .. }
         | ModelProvider::AzureAiFoundry { .. }
         | ModelProvider::AwsBedrock { .. }
-        | ModelProvider::GoogleVertex { .. } => {
+        | ModelProvider::GoogleVertex { .. }
+        | ModelProvider::AlibabaCloud { .. } => {
             let resolved = ms.inner.api_format.resolve(&ms.model);
             if resolved == distri_types::ResolvedOpenAiApiFormat::Responses {
                 Ok(Box::new(

--- a/server/distri-core/src/openai_responses_llm.rs
+++ b/server/distri-core/src/openai_responses_llm.rs
@@ -130,6 +130,16 @@ impl OpenAIResponsesLLMExecutor {
                 let url_with_version = format!("{}?api-version={}", azure_base, api_version);
                 (url_with_version, String::new()) // Empty api_key since we use header
             }
+            ModelProvider::AlibabaCloud { base_url, api_key } => {
+                let key = if let Some(key) = api_key {
+                    key.clone()
+                } else {
+                    secret_resolver
+                        .resolve_or_empty("DASHSCOPE_API_KEY")
+                        .await
+                };
+                (base_url.clone(), key)
+            }
             other => {
                 return Err(AgentError::InvalidConfiguration(format!(
                     "OpenAI Responses API format is not supported for {:?} provider",

--- a/server/llm-gateway/src/provider_config.rs
+++ b/server/llm-gateway/src/provider_config.rs
@@ -114,6 +114,15 @@ impl From<&ModelProvider> for ProviderClientConfig {
                 query_params: vec![],
                 send_api_key_header: true,
             },
+            ModelProvider::AlibabaCloud { base_url, api_key } => Self {
+                base_url: base_url.clone(),
+                api_key_secret: "DASHSCOPE_API_KEY",
+                inline_api_key: api_key.clone(),
+                project_id: None,
+                extra_headers: HashMap::new(),
+                query_params: vec![],
+                send_api_key_header: false,
+            },
         }
     }
 }
@@ -255,6 +264,7 @@ mod tests {
             ("azure_ai_foundry", "AZURE_AI_FOUNDRY_API_KEY"),
             ("aws_bedrock", "AWS_ACCESS_KEY_ID"),
             ("google_vertex", "GOOGLE_VERTEX_API_KEY"),
+            ("alibaba_cloud", "DASHSCOPE_API_KEY"),
         ];
         for (provider_str, expected_secret) in cases {
             let ms = distri_types::ModelSettings::from_provider_model_str(&format!(


### PR DESCRIPTION
## Summary
This PR adds support for Alibaba Cloud's DashScope API as a new LLM provider, enabling users to integrate Qwen models into the system.

## Key Changes

- **Provider Configuration**: Added `AlibabaCloud` variant to `ModelProvider` enum with support for DashScope API key authentication and configurable base URL
- **Model Definitions**: Added two Qwen models to the default models configuration:
  - Qwen3.6 Plus (1M context window)
  - Qwen3.5 35B A3B (262K context window)
- **API Integration**: Implemented OpenAI-compatible API format support for Alibaba Cloud with proper header-based authentication
- **Provider Type**: Added `AlibabaCloud` to the `ProviderType` enum with appropriate string representations and conversions
- **Secret Management**: Configured `DASHSCOPE_API_KEY` as the environment variable for API key resolution
- **Pricing Data**: Added pricing information for both Qwen models to the pricing configuration
- **LLM Executor**: Integrated Alibaba Cloud provider into the LLM executor creation logic to use OpenAI Responses API format

## Implementation Details

- Uses DashScope's OpenAI-compatible endpoint: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
- API key is sent via the `Authorization` header (not as query parameter)
- Both models support prompt caching with reduced input token pricing
- Pricing is specified in USD per 1M tokens, consistent with other providers

https://claude.ai/code/session_01ArPXhSnoSo9C9TfqH1RJSe