### PR TITLE
Add trace inspection with Gantt chart visualization

### DIFF
--- a/distri-cli/src/chat.rs
+++ b/distri-cli/src/chat.rs
@@ -147,6 +147,8 @@ pub fn print_help_message() {
     println!("  /resume             - Pick from recent threads to resume");
     println!("  /resume last        - Resume the last thread from previous session");
     println!("  /resume <id>        - Resume a specific thread by ID");
+    println!("  /traces             - List recent traces");
+    println!("  /traces <id>        - Show trace detail with Gantt chart");
     println!("  /clear              - Clear the current session context");
     println!("  /help               - Show this help message");
     println!("  /exit               - Exit the chat");
@@ -396,6 +398,15 @@ pub async fn handle_slash_command(
                     Ok(SlashCommandResult::Continue)
                 }
             }
+        }
+        "/traces" => {
+            let client = Distri::from_config(config.clone());
+            if let Some(trace_id) = arg {
+                crate::traces::print_trace_detail(&client, trace_id, None).await;
+            } else {
+                crate::traces::print_trace_list(&client, 20).await;
+            }
+            Ok(SlashCommandResult::Continue)
         }
         _ => {
             println!("Unknown command. Type /help for commands.");

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -17,6 +17,7 @@ mod login;
 mod message;
 mod threads;
 mod tools;
+mod traces;
 
 use chat::run_interactive_chat;
 use commands::{
@@ -131,6 +132,12 @@ enum Commands {
     Threads {
         #[clap(subcommand)]
         command: ThreadsCommands,
+    },
+
+    /// Trace inspection commands
+    Traces {
+        #[clap(subcommand)]
+        command: TracesCommands,
     },
 
     /// Manage local client configuration
@@ -276,6 +283,24 @@ pub(crate) enum SecretsCommands {
 pub(crate) enum ThreadsCommands {
     /// List all threads
     List,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum TracesCommands {
+    /// List recent traces
+    List {
+        #[clap(long, default_value = "20")]
+        limit: i64,
+    },
+    /// Show trace detail with Gantt chart
+    Show {
+        /// Trace ID, span ID, or thread ID
+        #[clap(help = "Trace ID, span ID, or thread ID")]
+        id: String,
+        /// Filter by span name or ID
+        #[clap(long)]
+        span: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -629,6 +654,9 @@ async fn main() -> Result<()> {
         }
         Commands::Threads { command } => {
             threads::handle_threads_command(&client, command).await?;
+        }
+        Commands::Traces { command } => {
+            traces::handle_traces_command(&client, command).await?;
         }
         Commands::Workflows { command } => {
             handle_workflow_command(&client, command).await?;

--- a/distri-cli/src/traces.rs
+++ b/distri-cli/src/traces.rs
@@ -1,0 +1,898 @@
+use anyhow::Result;
+use crossterm::terminal;
+use distri::{Distri, TraceSummary};
+
+use crate::{TracesCommands, COLOR_BRIGHT_GREEN, COLOR_BRIGHT_MAGENTA, COLOR_GRAY, COLOR_RESET};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ANSI color constants for span categories
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COLOR_PURPLE: &str = "\x1b[35m";
+const COLOR_YELLOW: &str = "\x1b[33m";
+const COLOR_BLUE: &str = "\x1b[34m";
+const COLOR_CYAN: &str = "\x1b[36m";
+const COLOR_GREEN: &str = "\x1b[32m";
+const COLOR_BRIGHT_YELLOW: &str = "\x1b[93m";
+const COLOR_BRIGHT_BLUE: &str = "\x1b[94m";
+const COLOR_BRIGHT_CYAN: &str = "\x1b[96m";
+const COLOR_WHITE: &str = "\x1b[37m";
+const COLOR_DIM: &str = "\x1b[2m";
+const COLOR_BOLD: &str = "\x1b[1m";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Span category
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+enum SpanCategory {
+    LlmCall,
+    ToolExecution,
+    AgentInvocation,
+    ChainOperation,
+    Plan,
+    Step,
+    AgentHandover,
+    Guardrail,
+    Unknown,
+}
+
+impl SpanCategory {
+    fn label(&self) -> &str {
+        match self {
+            Self::LlmCall => "LLM",
+            Self::ToolExecution => "Tool",
+            Self::AgentInvocation => "Agent",
+            Self::ChainOperation => "Chain",
+            Self::Plan => "Plan",
+            Self::Step => "Step",
+            Self::AgentHandover => "Handover",
+            Self::Guardrail => "Guard",
+            Self::Unknown => "Span",
+        }
+    }
+
+    fn color(&self) -> &str {
+        match self {
+            Self::LlmCall => COLOR_PURPLE,
+            Self::ToolExecution => COLOR_YELLOW,
+            Self::AgentInvocation => COLOR_BLUE,
+            Self::ChainOperation => COLOR_GREEN,
+            Self::Plan => COLOR_CYAN,
+            Self::Step => COLOR_WHITE,
+            Self::AgentHandover => COLOR_BRIGHT_MAGENTA,
+            Self::Guardrail => COLOR_BRIGHT_YELLOW,
+            Self::Unknown => COLOR_GRAY,
+        }
+    }
+
+    fn bar_char(&self) -> &str {
+        match self {
+            Self::LlmCall => "█",
+            Self::ToolExecution => "█",
+            Self::AgentInvocation => "█",
+            Self::ChainOperation => "█",
+            Self::Plan => "█",
+            Self::Step => "█",
+            Self::AgentHandover => "█",
+            Self::Guardrail => "█",
+            Self::Unknown => "█",
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parsed span
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct CliSpan {
+    span_id: String,
+    parent_span_id: Option<String>,
+    name: String,
+    start_time_ns: i64,
+    end_time_ns: i64,
+    attributes: Vec<(String, String)>,
+    children: Vec<CliSpan>,
+}
+
+impl CliSpan {
+    fn duration_ns(&self) -> i64 {
+        self.end_time_ns - self.start_time_ns
+    }
+
+    fn get_attr(&self, key: &str) -> Option<&str> {
+        self.attributes
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn category(&self) -> SpanCategory {
+        // Check gen_ai.operation.name first for custom distri operations
+        if let Some(op) = self.get_attr("gen_ai.operation.name") {
+            match op {
+                "plan" => return SpanCategory::Plan,
+                "step" => return SpanCategory::Step,
+                "agent_handover" => return SpanCategory::AgentHandover,
+                "execute" => return SpanCategory::AgentInvocation,
+                _ => {}
+            }
+        }
+
+        // Detect from openinference.span.kind or name patterns
+        if let Some(kind) = self.get_attr("openinference.span.kind") {
+            match kind.to_uppercase().as_str() {
+                "LLM" => return SpanCategory::LlmCall,
+                "TOOL" => return SpanCategory::ToolExecution,
+                "AGENT" => return SpanCategory::AgentInvocation,
+                "CHAIN" => return SpanCategory::ChainOperation,
+                "RETRIEVER" => return SpanCategory::ChainOperation,
+                "EMBEDDING" => return SpanCategory::LlmCall,
+                "GUARDRAIL" => return SpanCategory::Guardrail,
+                _ => {}
+            }
+        }
+
+        // Detect from gen_ai.operation.name for standard operations
+        if let Some(op) = self.get_attr("gen_ai.operation.name") {
+            match op {
+                "chat" | "completion" => return SpanCategory::LlmCall,
+                _ => {}
+            }
+        }
+
+        // Detect LLM by model attribute
+        if self.get_attr("gen_ai.request.model").is_some() {
+            return SpanCategory::LlmCall;
+        }
+
+        // Detect tool by name
+        if self.get_attr("gen_ai.tool.call.arguments").is_some() {
+            return SpanCategory::ToolExecution;
+        }
+
+        SpanCategory::Unknown
+    }
+
+    fn clean_title(&self) -> String {
+        let cat = self.category();
+        let op = self.get_attr("gen_ai.operation.name");
+
+        match cat {
+            SpanCategory::LlmCall => {
+                // Use model name if available
+                if let Some(model) = self.get_attr("gen_ai.request.model") {
+                    return model.to_string();
+                }
+                // Title is "model - span_name", take just the model
+                if let Some(idx) = self.name.find(" - ") {
+                    return self.name[..idx].to_string();
+                }
+                self.name.clone()
+            }
+            SpanCategory::AgentInvocation => self
+                .name
+                .replace("invoke_agent ", "")
+                .replace("execute ", ""),
+            SpanCategory::ToolExecution => self.name.replace("execute_tool ", ""),
+            SpanCategory::Plan => {
+                if self.name.contains("initial") {
+                    "Planning (initial)".to_string()
+                } else {
+                    "Re-planning".to_string()
+                }
+            }
+            SpanCategory::Step => {
+                if let Some(op_name) = op {
+                    if op_name == "step" {
+                        // "step 0" → "Step 0"
+                        let title = self.name.replace("step ", "Step ");
+                        if title == self.name {
+                            format!("Step {}", self.name)
+                        } else {
+                            title
+                        }
+                    } else {
+                        self.name.clone()
+                    }
+                } else {
+                    self.name.clone()
+                }
+            }
+            SpanCategory::AgentHandover => self.name.replace("handover ", ""),
+            _ => self.name.clone(),
+        }
+    }
+
+    fn input_tokens(&self) -> Option<i64> {
+        self.get_attr("gen_ai.usage.input_tokens")
+            .and_then(|v| v.parse().ok())
+    }
+
+    fn cost(&self) -> Option<f64> {
+        self.get_attr("gen_ai.usage.cost")
+            .and_then(|v| v.parse().ok())
+    }
+
+    fn input_value(&self) -> Option<&str> {
+        self.get_attr("input.value")
+    }
+
+    fn output_value(&self) -> Option<&str> {
+        self.get_attr("output.value")
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OTLP JSON → CliSpan tree
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn parse_otlp_spans(otlp: &serde_json::Value) -> Vec<CliSpan> {
+    let mut flat: Vec<CliSpan> = Vec::new();
+
+    let resource_spans = match otlp.get("resourceSpans").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return flat,
+    };
+
+    for rs in resource_spans {
+        let scope_spans = match rs.get("scopeSpans").and_then(|v| v.as_array()) {
+            Some(arr) => arr,
+            None => continue,
+        };
+        for ss in scope_spans {
+            let spans = match ss.get("spans").and_then(|v| v.as_array()) {
+                Some(arr) => arr,
+                None => continue,
+            };
+            for span_obj in spans {
+                if let Some(cli_span) = parse_single_span(span_obj) {
+                    flat.push(cli_span);
+                }
+            }
+        }
+    }
+
+    build_tree(flat)
+}
+
+fn parse_single_span(v: &serde_json::Value) -> Option<CliSpan> {
+    let span_id = v.get("spanId")?.as_str()?.to_string();
+    let parent_raw = v
+        .get("parentSpanId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let parent_span_id = if parent_raw.is_empty() {
+        None
+    } else {
+        Some(parent_raw.to_string())
+    };
+    let name = v.get("name")?.as_str()?.to_string();
+
+    let start_time_ns = v
+        .get("startTimeUnixNano")
+        .and_then(|v| v.as_str().or_else(|| v.as_i64().map(|_| "")))
+        .and_then(|s| {
+            if s.is_empty() {
+                v.get("startTimeUnixNano").and_then(|v| v.as_i64())
+            } else {
+                s.parse().ok()
+            }
+        })
+        .unwrap_or(0);
+
+    let end_time_ns = v
+        .get("endTimeUnixNano")
+        .and_then(|v| v.as_str().or_else(|| v.as_i64().map(|_| "")))
+        .and_then(|s| {
+            if s.is_empty() {
+                v.get("endTimeUnixNano").and_then(|v| v.as_i64())
+            } else {
+                s.parse().ok()
+            }
+        })
+        .unwrap_or(0);
+
+    let mut attributes = Vec::new();
+    if let Some(attrs) = v.get("attributes").and_then(|v| v.as_array()) {
+        for attr in attrs {
+            if let (Some(key), Some(value)) = (
+                attr.get("key").and_then(|v| v.as_str()),
+                attr.get("value"),
+            ) {
+                let val_str = extract_otlp_value(value);
+                attributes.push((key.to_string(), val_str));
+            }
+        }
+    }
+
+    Some(CliSpan {
+        span_id,
+        parent_span_id,
+        name,
+        start_time_ns,
+        end_time_ns,
+        attributes,
+        children: Vec::new(),
+    })
+}
+
+fn extract_otlp_value(v: &serde_json::Value) -> String {
+    if let Some(s) = v.get("stringValue").and_then(|v| v.as_str()) {
+        return s.to_string();
+    }
+    if let Some(s) = v.get("intValue").and_then(|v| v.as_str()) {
+        return s.to_string();
+    }
+    if let Some(n) = v.get("intValue").and_then(|v| v.as_i64()) {
+        return n.to_string();
+    }
+    if let Some(n) = v.get("doubleValue").and_then(|v| v.as_f64()) {
+        return n.to_string();
+    }
+    if let Some(b) = v.get("boolValue").and_then(|v| v.as_bool()) {
+        return b.to_string();
+    }
+    v.to_string()
+}
+
+fn build_tree(mut flat: Vec<CliSpan>) -> Vec<CliSpan> {
+    use std::collections::HashMap;
+
+    // Sort by start time
+    flat.sort_by_key(|s| s.start_time_ns);
+
+    // Index by span_id
+    let mut map: HashMap<String, CliSpan> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for span in flat {
+        order.push(span.span_id.clone());
+        map.insert(span.span_id.clone(), span);
+    }
+
+    // Collect parent-child relationships
+    let mut children_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut root_ids: Vec<String> = Vec::new();
+
+    for id in &order {
+        let span = map.get(id).unwrap();
+        if let Some(ref parent_id) = span.parent_span_id {
+            if map.contains_key(parent_id) {
+                children_map
+                    .entry(parent_id.clone())
+                    .or_default()
+                    .push(id.clone());
+            } else {
+                root_ids.push(id.clone());
+            }
+        } else {
+            root_ids.push(id.clone());
+        }
+    }
+
+    // Build tree recursively
+    fn assemble(
+        id: &str,
+        map: &mut HashMap<String, CliSpan>,
+        children_map: &HashMap<String, Vec<String>>,
+    ) -> Option<CliSpan> {
+        let mut span = map.remove(id)?;
+        if let Some(child_ids) = children_map.get(id) {
+            for cid in child_ids {
+                if let Some(child) = assemble(cid, map, children_map) {
+                    span.children.push(child);
+                }
+            }
+            span.children.sort_by_key(|c| c.start_time_ns);
+        }
+        Some(span)
+    }
+
+    let mut roots = Vec::new();
+    for id in &root_ids {
+        if let Some(root) = assemble(id, &mut map, &children_map) {
+            roots.push(root);
+        }
+    }
+    roots.sort_by_key(|r| r.start_time_ns);
+    roots
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Formatting helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn format_duration_ns(ns: i64) -> String {
+    if ns <= 0 {
+        return "0ms".to_string();
+    }
+    let ms = ns as f64 / 1_000_000.0;
+    if ms < 1.0 {
+        return "<1ms".to_string();
+    }
+    if ms < 1000.0 {
+        return format!("{}ms", ms.round() as i64);
+    }
+    let secs = ms / 1000.0;
+    if secs < 60.0 {
+        return format!("{:.1}s", secs);
+    }
+    let mins = (secs / 60.0).floor() as i64;
+    let remaining_secs = (secs - (mins as f64 * 60.0)).round() as i64;
+    if mins < 60 {
+        if remaining_secs > 0 {
+            return format!("{}m {}s", mins, remaining_secs);
+        }
+        return format!("{}m", mins);
+    }
+    let hours = mins / 60;
+    let remaining_mins = mins % 60;
+    if remaining_mins > 0 {
+        format!("{}h {}m", hours, remaining_mins)
+    } else {
+        format!("{}h", hours)
+    }
+}
+
+fn format_tokens(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn format_cost(c: f64) -> String {
+    if c <= 0.0 {
+        return String::new();
+    }
+    if c < 0.001 {
+        format!("${:.6}", c)
+    } else if c < 0.01 {
+        format!("${:.4}", c)
+    } else {
+        format!("${:.2}", c)
+    }
+}
+
+fn term_width() -> usize {
+    terminal::size().map(|(w, _)| w as usize).unwrap_or(100)
+}
+
+fn separator(width: usize) -> String {
+    "─".repeat(width)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trace list display
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub async fn print_trace_list(client: &Distri, limit: i64) {
+    match client.list_traces(Some(limit)).await {
+        Ok(traces) => {
+            if traces.is_empty() {
+                println!("No traces found.");
+                return;
+            }
+            let width = term_width().min(90);
+            println!();
+            println!(
+                "  {}{}Traces{} ({} found)",
+                COLOR_BOLD,
+                COLOR_BRIGHT_GREEN,
+                COLOR_RESET,
+                traces.len()
+            );
+            println!("  {}{}{}", COLOR_GRAY, separator(width - 2), COLOR_RESET);
+            println!();
+
+            for trace in &traces {
+                print_trace_summary(trace, width);
+            }
+            println!(
+                "  {}{}{}\n",
+                COLOR_GRAY,
+                separator(width - 2),
+                COLOR_RESET
+            );
+            println!(
+                "  {}Use `distri traces show <trace-id>` to view details{}",
+                COLOR_GRAY, COLOR_RESET
+            );
+            println!();
+        }
+        Err(e) => {
+            eprintln!("Failed to list traces: {}", e);
+        }
+    }
+}
+
+fn print_trace_summary(trace: &TraceSummary, _width: usize) {
+    let duration = format_duration_ns(trace.end_time_ns - trace.start_time_ns);
+    let cost = format_cost(trace.total_cost);
+    let tokens = if trace.input_tokens > 0 {
+        format!("{}tokens", format_tokens(trace.input_tokens))
+    } else {
+        String::new()
+    };
+    let models: Vec<&str> = trace
+        .models
+        .iter()
+        .filter_map(|m| m.as_deref())
+        .collect();
+    let model_str = if models.is_empty() {
+        String::new()
+    } else {
+        models.join(", ")
+    };
+
+    // Line 1: name + stats
+    let trace_id_short = if trace.trace_id.len() > 10 {
+        &trace.trace_id[..10]
+    } else {
+        &trace.trace_id
+    };
+
+    println!(
+        "  {}{}{} {}  {}{}  {}{}  {}{}",
+        COLOR_BOLD,
+        trace.name,
+        COLOR_RESET,
+        format!(
+            "{}{} spans{}",
+            COLOR_GRAY, trace.span_count, COLOR_RESET
+        ),
+        COLOR_BRIGHT_CYAN,
+        duration,
+        COLOR_BRIGHT_YELLOW,
+        cost,
+        COLOR_GRAY,
+        COLOR_RESET,
+    );
+
+    // Line 2: trace ID, thread, tokens, models
+    let thread_str = trace
+        .thread_id
+        .as_deref()
+        .map(|t| {
+            let short = if t.len() > 8 { &t[..8] } else { t };
+            format!(" · {}", short)
+        })
+        .unwrap_or_default();
+    println!(
+        "  {}{}{}{}  {}{}  {}{}{}",
+        COLOR_GRAY,
+        trace_id_short,
+        thread_str,
+        COLOR_RESET,
+        COLOR_GRAY,
+        tokens,
+        COLOR_DIM,
+        model_str,
+        COLOR_RESET,
+    );
+
+    // Line 3: input preview (if any)
+    if let Some(ref preview) = trace.input_preview {
+        let trimmed = preview.trim();
+        if !trimmed.is_empty() {
+            let display = if trimmed.len() > 80 {
+                format!("{}...", &trimmed[..80])
+            } else {
+                trimmed.to_string()
+            };
+            println!("  {}{}{}", COLOR_DIM, display, COLOR_RESET);
+        }
+    }
+
+    println!();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trace detail (Gantt chart)
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub async fn print_trace_detail(client: &Distri, id: &str, span_filter: Option<&str>) {
+    // Try as trace_id first, then as thread_id
+    let otlp = match client.get_spans(Some(id), None).await {
+        Ok(v) => {
+            // Check if we got spans
+            let has_spans = v
+                .get("resourceSpans")
+                .and_then(|rs| rs.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false);
+            if has_spans {
+                v
+            } else {
+                // Try as thread_id
+                match client.get_spans(None, Some(id)).await {
+                    Ok(v2) => v2,
+                    Err(_) => v, // Use original empty response
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to get spans: {}", e);
+            return;
+        }
+    };
+
+    let roots = parse_otlp_spans(&otlp);
+    if roots.is_empty() {
+        println!("No spans found for '{}'.", id);
+        return;
+    }
+
+    // Find time range across all spans
+    let (min_start, max_end) = find_time_range(&roots);
+    let total_span_count = count_spans(&roots);
+
+    let width = term_width().min(120);
+    let bar_width = width.saturating_sub(40).max(20);
+
+    // Header
+    let root_name = roots.first().map(|r| r.name.as_str()).unwrap_or("trace");
+    let root_duration = format_duration_ns(max_end - min_start);
+
+    // Collect aggregate stats
+    let (total_tokens, total_cost) = aggregate_stats(&roots);
+
+    let id_short = if id.len() > 16 { &id[..16] } else { id };
+
+    println!();
+    println!(
+        "  {}{}Trace: {}{} {}({}){}\n  {}{} spans · {} · {}tokens · {}{}",
+        COLOR_BOLD,
+        COLOR_BRIGHT_GREEN,
+        root_name,
+        COLOR_RESET,
+        COLOR_GRAY,
+        id_short,
+        COLOR_RESET,
+        COLOR_GRAY,
+        total_span_count,
+        root_duration,
+        format_tokens(total_tokens),
+        format_cost(total_cost),
+        COLOR_RESET,
+    );
+    println!("  {}{}{}", COLOR_GRAY, separator(width - 2), COLOR_RESET);
+    println!();
+
+    // Render Gantt chart
+    for root in &roots {
+        render_span_row(root, 0, min_start, max_end, bar_width, span_filter);
+    }
+
+    println!("  {}{}{}", COLOR_GRAY, separator(width - 2), COLOR_RESET);
+
+    // Print input/output for root span
+    if let Some(root) = roots.first() {
+        let input = root.input_value();
+        let output = root.output_value();
+
+        if input.is_some() || output.is_some() {
+            println!();
+        }
+
+        if let Some(inp) = input {
+            let display = truncate_text(inp, 300);
+            println!(
+                "  {}{}INPUT:{}",
+                COLOR_BOLD, COLOR_BRIGHT_BLUE, COLOR_RESET
+            );
+            for line in display.lines() {
+                println!("  {}{}{}", COLOR_DIM, line, COLOR_RESET);
+            }
+            println!();
+        }
+
+        if let Some(out) = output {
+            let display = truncate_text(out, 300);
+            println!(
+                "  {}{}OUTPUT:{}",
+                COLOR_BOLD, COLOR_BRIGHT_GREEN, COLOR_RESET
+            );
+            for line in display.lines() {
+                println!("  {}{}{}", COLOR_DIM, line, COLOR_RESET);
+            }
+            println!();
+        }
+    }
+}
+
+fn render_span_row(
+    span: &CliSpan,
+    depth: usize,
+    min_start: i64,
+    max_end: i64,
+    bar_width: usize,
+    span_filter: Option<&str>,
+) {
+    // If filtering, check if this span matches
+    if let Some(filter) = span_filter {
+        let filter_lower = filter.to_lowercase();
+        let matches = span.span_id.to_lowercase().contains(&filter_lower)
+            || span.name.to_lowercase().contains(&filter_lower)
+            || span.clean_title().to_lowercase().contains(&filter_lower);
+        if !matches {
+            // Still recurse into children
+            for child in &span.children {
+                render_span_row(child, depth, min_start, max_end, bar_width, span_filter);
+            }
+            return;
+        }
+    }
+
+    let cat = span.category();
+    let indent = "  ".repeat(depth + 1);
+    let title = span.clean_title();
+    let duration = format_duration_ns(span.duration_ns());
+
+    // Build info parts
+    let mut info_parts: Vec<String> = Vec::new();
+
+    if let Some(tokens) = span.input_tokens() {
+        if tokens > 0 {
+            info_parts.push(format!("{}{}↑{}", COLOR_GRAY, format_tokens(tokens), COLOR_RESET));
+        }
+    }
+    if let Some(cost) = span.cost() {
+        if cost > 0.0 {
+            info_parts.push(format!(
+                "{}{}{}",
+                COLOR_BRIGHT_YELLOW,
+                format_cost(cost),
+                COLOR_RESET
+            ));
+        }
+    }
+
+    let info_str = if info_parts.is_empty() {
+        String::new()
+    } else {
+        format!("  {}", info_parts.join("  "))
+    };
+
+    // Category badge
+    let badge = format!(
+        "{}[{}]{}",
+        cat.color(),
+        cat.label(),
+        COLOR_RESET
+    );
+
+    // Span row: indent + badge + title + info + duration
+    println!(
+        "{}{} {}{}{}  {}{}{}",
+        indent, badge, COLOR_BOLD, title, COLOR_RESET, info_str, COLOR_BRIGHT_CYAN, "",
+    );
+
+    // Right-align duration on same conceptual line - print on next sub-line with bar
+    // Calculate timeline bar
+    let total_range = max_end - min_start;
+    if total_range > 0 {
+        let start_pct = (span.start_time_ns - min_start) as f64 / total_range as f64;
+        let width_pct = span.duration_ns() as f64 / total_range as f64;
+
+        let bar_start = (start_pct * bar_width as f64) as usize;
+        let bar_len = (width_pct * bar_width as f64).max(1.0) as usize;
+        let bar_end = bar_width.saturating_sub(bar_start + bar_len);
+
+        let empty_char = "░";
+        let fill_char = cat.bar_char();
+
+        let bar = format!(
+            "{}{}{}{}{}{}",
+            COLOR_DIM,
+            empty_char.repeat(bar_start),
+            cat.color(),
+            fill_char.repeat(bar_len),
+            COLOR_DIM,
+            empty_char.repeat(bar_end),
+        );
+
+        let bar_indent = "  ".repeat(depth + 1);
+        let badge_space = " ".repeat(cat.label().len() + 3); // [XXX] + space
+        println!(
+            "{}{}{}{} {}{}{}",
+            bar_indent, badge_space, bar, COLOR_RESET, COLOR_BRIGHT_CYAN, duration, COLOR_RESET,
+        );
+    }
+
+    // Recurse into children
+    for child in &span.children {
+        render_span_row(child, depth + 1, min_start, max_end, bar_width, span_filter);
+    }
+}
+
+fn find_time_range(spans: &[CliSpan]) -> (i64, i64) {
+    let mut min_start = i64::MAX;
+    let mut max_end = i64::MIN;
+
+    fn walk(span: &CliSpan, min: &mut i64, max: &mut i64) {
+        if span.start_time_ns < *min {
+            *min = span.start_time_ns;
+        }
+        if span.end_time_ns > *max {
+            *max = span.end_time_ns;
+        }
+        for child in &span.children {
+            walk(child, min, max);
+        }
+    }
+
+    for span in spans {
+        walk(span, &mut min_start, &mut max_end);
+    }
+
+    if min_start == i64::MAX {
+        (0, 1)
+    } else {
+        (min_start, max_end)
+    }
+}
+
+fn count_spans(spans: &[CliSpan]) -> usize {
+    fn walk(span: &CliSpan) -> usize {
+        1 + span.children.iter().map(walk).sum::<usize>()
+    }
+    spans.iter().map(walk).sum()
+}
+
+fn aggregate_stats(spans: &[CliSpan]) -> (i64, f64) {
+    fn walk(span: &CliSpan, tokens: &mut i64, cost: &mut f64) {
+        if let Some(t) = span.input_tokens() {
+            *tokens += t;
+        }
+        if let Some(c) = span.cost() {
+            *cost += c;
+        }
+        for child in &span.children {
+            walk(child, tokens, cost);
+        }
+    }
+
+    let mut tokens = 0i64;
+    let mut cost = 0.0f64;
+    for span in spans {
+        walk(span, &mut tokens, &mut cost);
+    }
+    (tokens, cost)
+}
+
+fn truncate_text(text: &str, max_len: usize) -> String {
+    // Clean up whitespace and strip [external_tools: ...] suffix
+    let cleaned = text
+        .trim()
+        .lines()
+        .take(10)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if cleaned.len() > max_len {
+        format!("{}...", &cleaned[..max_len])
+    } else {
+        cleaned
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub async fn handle_traces_command(client: &Distri, command: TracesCommands) -> Result<()> {
+    match command {
+        TracesCommands::List { limit } => {
+            print_trace_list(client, limit).await;
+        }
+        TracesCommands::Show { id, span } => {
+            print_trace_detail(client, &id, span.as_deref()).await;
+        }
+    }
+    Ok(())
+}

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -2044,6 +2044,30 @@ pub struct NewSecretRequest {
     pub value: String,
 }
 
+// ========== Traces API ==========
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceSummary {
+    pub trace_id: String,
+    pub name: String,
+    pub start_time_ns: i64,
+    pub end_time_ns: i64,
+    pub span_count: i64,
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    #[serde(default)]
+    pub input_tokens: i64,
+    #[serde(default)]
+    pub total_cost: f64,
+    #[serde(default)]
+    pub step_count: i64,
+    #[serde(default)]
+    pub models: Vec<Option<String>>,
+    #[serde(default)]
+    pub input_preview: Option<String>,
+}
+
 // ========== Threads API ==========
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2575,6 +2599,63 @@ impl Distri {
             .collect();
 
         Ok(items)
+    }
+
+    // ========== Traces API ==========
+
+    pub async fn list_traces(
+        &self,
+        limit: Option<i64>,
+    ) -> Result<Vec<TraceSummary>, ClientError> {
+        let mut url = format!("{}/traces", self.base_url);
+        if let Some(limit) = limit {
+            url = format!("{}?limit={}", url, limit);
+        }
+        let resp = self.http.get(&url).send().await?;
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ClientError::InvalidResponse(format!(
+                "failed to list traces: {}",
+                text
+            )));
+        }
+        let body: serde_json::Value = resp.json().await?;
+        let arr = if let Some(traces) = body.get("traces") {
+            traces.clone()
+        } else {
+            body
+        };
+        serde_json::from_value(arr)
+            .map_err(|e| ClientError::InvalidResponse(format!("failed to parse traces: {}", e)))
+    }
+
+    pub async fn get_spans(
+        &self,
+        trace_id: Option<&str>,
+        thread_id: Option<&str>,
+    ) -> Result<serde_json::Value, ClientError> {
+        let mut params = vec![];
+        if let Some(tid) = trace_id {
+            params.push(format!("trace_id={}", tid));
+        }
+        if let Some(tid) = thread_id {
+            params.push(format!("thread_id={}", tid));
+        }
+        let url = if params.is_empty() {
+            format!("{}/spans", self.base_url)
+        } else {
+            format!("{}/spans?{}", self.base_url, params.join("&"))
+        };
+        let resp = self.http.get(&url).send().await?;
+        if resp.status().is_success() {
+            Ok(resp.json().await?)
+        } else {
+            let text = resp.text().await.unwrap_or_default();
+            Err(ClientError::InvalidResponse(format!(
+                "failed to get spans: {}",
+                text
+            )))
+        }
     }
 
     // ========== Workflows API ==========

--- a/distri/src/lib.rs
+++ b/distri/src/lib.rs
@@ -24,7 +24,8 @@ pub use client::{
     Distri, InvokeOptions, LlmExecuteOptions, LlmExecuteResponse, LoginUrlResponse,
     NewPromptTemplateRequest, NewSecretRequest, PluginResponse, PluginsListResponse,
     PromptTemplateResponse, ProviderInfo, SecretEntry, SkillListItemResponse, SkillResponse,
-    SyncPromptTemplatesResponse, TaskNamespaceResponse, ThreadSummary, TtsModelsResponse,
+    SyncPromptTemplatesResponse, TaskNamespaceResponse, ThreadSummary, TraceSummary,
+    TtsModelsResponse,
     TtsSpeechRequest, TtsSpeechResponse, UpdatePluginRequest, UpdateSkillRequest,
     ValidatePluginResponse, WorkspaceResponse,
 };


### PR DESCRIPTION
## Summary
Add comprehensive trace inspection capabilities to the CLI with a visual Gantt chart display. This enables users to view distributed traces, analyze span hierarchies, and understand execution timelines with cost and token metrics.

## Key Changes

- **New `traces` module** (`distri-cli/src/traces.rs`): Complete trace visualization system with:
  - OTLP JSON parsing and span tree construction
  - Span categorization (LLM, Tool, Agent, Chain, Plan, Step, Guardrail, etc.)
  - Gantt chart rendering with color-coded span categories
  - Duration, token, and cost formatting and aggregation
  - Span filtering by name or ID

- **Traces API client methods** (`distri/src/client.rs`):
  - `list_traces()`: Fetch recent traces with summaries
  - `get_spans()`: Retrieve detailed span data by trace ID or thread ID
  - `TraceSummary` struct: Trace metadata including duration, costs, models, and input preview

- **CLI commands** (`distri-cli/src/main.rs`):
  - `distri traces list [--limit N]`: List recent traces with statistics
  - `distri traces show <id> [--span FILTER]`: Display trace detail with Gantt chart and optional span filtering

- **Interactive chat integration** (`distri-cli/src/chat.rs`):
  - `/traces` command to list recent traces
  - `/traces <id>` command to show trace details

## Implementation Details

- Spans are parsed from OTLP JSON format and organized into a tree structure based on parent-child relationships
- Span categories are detected using OpenInference and custom Distri attributes
- Timeline visualization uses Unicode box-drawing characters with proportional bar widths
- Aggregate statistics (total tokens, cost) are computed across all spans in a trace
- Terminal width is detected and used to scale the Gantt chart appropriately
- Input/output values from root spans are displayed with truncation for readability

https://claude.ai/code/session_01Gtgikzd3CDQ4Dm7A2w6uni