### PR TITLE
feat: CLI traces and debugging flags, support multi entry workflows, render structured implementation

### DIFF
--- a/distri-cli/src/chat.rs
+++ b/distri-cli/src/chat.rs
@@ -147,6 +147,8 @@ pub fn print_help_message() {
     println!("  /resume             - Pick from recent threads to resume");
     println!("  /resume last        - Resume the last thread from previous session");
     println!("  /resume <id>        - Resume a specific thread by ID");
+    println!("  /traces             - List recent traces");
+    println!("  /traces <id>        - Show trace detail with Gantt chart");
     println!("  /clear              - Clear the current session context");
     println!("  /help               - Show this help message");
     println!("  /exit               - Exit the chat");
@@ -396,6 +398,15 @@ pub async fn handle_slash_command(
                     Ok(SlashCommandResult::Continue)
                 }
             }
+        }
+        "/traces" => {
+            let client = Distri::from_config(config.clone());
+            if let Some(trace_id) = arg {
+                crate::traces::print_trace_detail(&client, trace_id, None).await;
+            } else {
+                crate::traces::print_trace_list(&client, 20).await;
+            }
+            Ok(SlashCommandResult::Continue)
         }
         _ => {
             println!("Unknown command. Type /help for commands.");

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -17,6 +17,7 @@ mod login;
 mod message;
 mod threads;
 mod tools;
+mod traces;
 
 use chat::run_interactive_chat;
 use commands::{
@@ -131,6 +132,12 @@ enum Commands {
     Threads {
         #[clap(subcommand)]
         command: ThreadsCommands,
+    },
+
+    /// Trace inspection commands
+    Traces {
+        #[clap(subcommand)]
+        command: TracesCommands,
     },
 
     /// Manage local client configuration
@@ -276,6 +283,24 @@ pub(crate) enum SecretsCommands {
 pub(crate) enum ThreadsCommands {
     /// List all threads
     List,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum TracesCommands {
+    /// List recent traces
+    List {
+        #[clap(long, default_value = "20")]
+        limit: i64,
+    },
+    /// Show trace detail with Gantt chart
+    Show {
+        /// Trace ID, span ID, or thread ID
+        #[clap(help = "Trace ID, span ID, or thread ID")]
+        id: String,
+        /// Filter by span name or ID
+        #[clap(long)]
+        span: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -634,6 +659,9 @@ async fn main() -> Result<()> {
         }
         Commands::Threads { command } => {
             threads::handle_threads_command(&client, command).await?;
+        }
+        Commands::Traces { command } => {
+            traces::handle_traces_command(&client, command).await?;
         }
         Commands::Workflows { command } => {
             handle_workflow_command(&client, command).await?;

--- a/distri-cli/src/traces.rs
+++ b/distri-cli/src/traces.rs
@@ -1,0 +1,898 @@
+use anyhow::Result;
+use crossterm::terminal;
+use distri::{Distri, TraceSummary};
+
+use crate::{TracesCommands, COLOR_BRIGHT_GREEN, COLOR_BRIGHT_MAGENTA, COLOR_GRAY, COLOR_RESET};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ANSI color constants for span categories
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COLOR_PURPLE: &str = "\x1b[35m";
+const COLOR_YELLOW: &str = "\x1b[33m";
+const COLOR_BLUE: &str = "\x1b[34m";
+const COLOR_CYAN: &str = "\x1b[36m";
+const COLOR_GREEN: &str = "\x1b[32m";
+const COLOR_BRIGHT_YELLOW: &str = "\x1b[93m";
+const COLOR_BRIGHT_BLUE: &str = "\x1b[94m";
+const COLOR_BRIGHT_CYAN: &str = "\x1b[96m";
+const COLOR_WHITE: &str = "\x1b[37m";
+const COLOR_DIM: &str = "\x1b[2m";
+const COLOR_BOLD: &str = "\x1b[1m";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Span category
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+enum SpanCategory {
+    LlmCall,
+    ToolExecution,
+    AgentInvocation,
+    ChainOperation,
+    Plan,
+    Step,
+    AgentHandover,
+    Guardrail,
+    Unknown,
+}
+
+impl SpanCategory {
+    fn label(&self) -> &str {
+        match self {
+            Self::LlmCall => "LLM",
+            Self::ToolExecution => "Tool",
+            Self::AgentInvocation => "Agent",
+            Self::ChainOperation => "Chain",
+            Self::Plan => "Plan",
+            Self::Step => "Step",
+            Self::AgentHandover => "Handover",
+            Self::Guardrail => "Guard",
+            Self::Unknown => "Span",
+        }
+    }
+
+    fn color(&self) -> &str {
+        match self {
+            Self::LlmCall => COLOR_PURPLE,
+            Self::ToolExecution => COLOR_YELLOW,
+            Self::AgentInvocation => COLOR_BLUE,
+            Self::ChainOperation => COLOR_GREEN,
+            Self::Plan => COLOR_CYAN,
+            Self::Step => COLOR_WHITE,
+            Self::AgentHandover => COLOR_BRIGHT_MAGENTA,
+            Self::Guardrail => COLOR_BRIGHT_YELLOW,
+            Self::Unknown => COLOR_GRAY,
+        }
+    }
+
+    fn bar_char(&self) -> &str {
+        match self {
+            Self::LlmCall => "█",
+            Self::ToolExecution => "█",
+            Self::AgentInvocation => "█",
+            Self::ChainOperation => "█",
+            Self::Plan => "█",
+            Self::Step => "█",
+            Self::AgentHandover => "█",
+            Self::Guardrail => "█",
+            Self::Unknown => "█",
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parsed span
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct CliSpan {
+    span_id: String,
+    parent_span_id: Option<String>,
+    name: String,
+    start_time_ns: i64,
+    end_time_ns: i64,
+    attributes: Vec<(String, String)>,
+    children: Vec<CliSpan>,
+}
+
+impl CliSpan {
+    fn duration_ns(&self) -> i64 {
+        self.end_time_ns - self.start_time_ns
+    }
+
+    fn get_attr(&self, key: &str) -> Option<&str> {
+        self.attributes
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    fn category(&self) -> SpanCategory {
+        // Check gen_ai.operation.name first for custom distri operations
+        if let Some(op) = self.get_attr("gen_ai.operation.name") {
+            match op {
+                "plan" => return SpanCategory::Plan,
+                "step" => return SpanCategory::Step,
+                "agent_handover" => return SpanCategory::AgentHandover,
+                "execute" => return SpanCategory::AgentInvocation,
+                _ => {}
+            }
+        }
+
+        // Detect from openinference.span.kind or name patterns
+        if let Some(kind) = self.get_attr("openinference.span.kind") {
+            match kind.to_uppercase().as_str() {
+                "LLM" => return SpanCategory::LlmCall,
+                "TOOL" => return SpanCategory::ToolExecution,
+                "AGENT" => return SpanCategory::AgentInvocation,
+                "CHAIN" => return SpanCategory::ChainOperation,
+                "RETRIEVER" => return SpanCategory::ChainOperation,
+                "EMBEDDING" => return SpanCategory::LlmCall,
+                "GUARDRAIL" => return SpanCategory::Guardrail,
+                _ => {}
+            }
+        }
+
+        // Detect from gen_ai.operation.name for standard operations
+        if let Some(op) = self.get_attr("gen_ai.operation.name") {
+            match op {
+                "chat" | "completion" => return SpanCategory::LlmCall,
+                _ => {}
+            }
+        }
+
+        // Detect LLM by model attribute
+        if self.get_attr("gen_ai.request.model").is_some() {
+            return SpanCategory::LlmCall;
+        }
+
+        // Detect tool by name
+        if self.get_attr("gen_ai.tool.call.arguments").is_some() {
+            return SpanCategory::ToolExecution;
+        }
+
+        SpanCategory::Unknown
+    }
+
+    fn clean_title(&self) -> String {
+        let cat = self.category();
+        let op = self.get_attr("gen_ai.operation.name");
+
+        match cat {
+            SpanCategory::LlmCall => {
+                // Use model name if available
+                if let Some(model) = self.get_attr("gen_ai.request.model") {
+                    return model.to_string();
+                }
+                // Title is "model - span_name", take just the model
+                if let Some(idx) = self.name.find(" - ") {
+                    return self.name[..idx].to_string();
+                }
+                self.name.clone()
+            }
+            SpanCategory::AgentInvocation => self
+                .name
+                .replace("invoke_agent ", "")
+                .replace("execute ", ""),
+            SpanCategory::ToolExecution => self.name.replace("execute_tool ", ""),
+            SpanCategory::Plan => {
+                if self.name.contains("initial") {
+                    "Planning (initial)".to_string()
+                } else {
+                    "Re-planning".to_string()
+                }
+            }
+            SpanCategory::Step => {
+                if let Some(op_name) = op {
+                    if op_name == "step" {
+                        // "step 0" → "Step 0"
+                        let title = self.name.replace("step ", "Step ");
+                        if title == self.name {
+                            format!("Step {}", self.name)
+                        } else {
+                            title
+                        }
+                    } else {
+                        self.name.clone()
+                    }
+                } else {
+                    self.name.clone()
+                }
+            }
+            SpanCategory::AgentHandover => self.name.replace("handover ", ""),
+            _ => self.name.clone(),
+        }
+    }
+
+    fn input_tokens(&self) -> Option<i64> {
+        self.get_attr("gen_ai.usage.input_tokens")
+            .and_then(|v| v.parse().ok())
+    }
+
+    fn cost(&self) -> Option<f64> {
+        self.get_attr("gen_ai.usage.cost")
+            .and_then(|v| v.parse().ok())
+    }
+
+    fn input_value(&self) -> Option<&str> {
+        self.get_attr("input.value")
+    }
+
+    fn output_value(&self) -> Option<&str> {
+        self.get_attr("output.value")
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OTLP JSON → CliSpan tree
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn parse_otlp_spans(otlp: &serde_json::Value) -> Vec<CliSpan> {
+    let mut flat: Vec<CliSpan> = Vec::new();
+
+    let resource_spans = match otlp.get("resourceSpans").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return flat,
+    };
+
+    for rs in resource_spans {
+        let scope_spans = match rs.get("scopeSpans").and_then(|v| v.as_array()) {
+            Some(arr) => arr,
+            None => continue,
+        };
+        for ss in scope_spans {
+            let spans = match ss.get("spans").and_then(|v| v.as_array()) {
+                Some(arr) => arr,
+                None => continue,
+            };
+            for span_obj in spans {
+                if let Some(cli_span) = parse_single_span(span_obj) {
+                    flat.push(cli_span);
+                }
+            }
+        }
+    }
+
+    build_tree(flat)
+}
+
+fn parse_single_span(v: &serde_json::Value) -> Option<CliSpan> {
+    let span_id = v.get("spanId")?.as_str()?.to_string();
+    let parent_raw = v
+        .get("parentSpanId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let parent_span_id = if parent_raw.is_empty() {
+        None
+    } else {
+        Some(parent_raw.to_string())
+    };
+    let name = v.get("name")?.as_str()?.to_string();
+
+    let start_time_ns = v
+        .get("startTimeUnixNano")
+        .and_then(|v| v.as_str().or_else(|| v.as_i64().map(|_| "")))
+        .and_then(|s| {
+            if s.is_empty() {
+                v.get("startTimeUnixNano").and_then(|v| v.as_i64())
+            } else {
+                s.parse().ok()
+            }
+        })
+        .unwrap_or(0);
+
+    let end_time_ns = v
+        .get("endTimeUnixNano")
+        .and_then(|v| v.as_str().or_else(|| v.as_i64().map(|_| "")))
+        .and_then(|s| {
+            if s.is_empty() {
+                v.get("endTimeUnixNano").and_then(|v| v.as_i64())
+            } else {
+                s.parse().ok()
+            }
+        })
+        .unwrap_or(0);
+
+    let mut attributes = Vec::new();
+    if let Some(attrs) = v.get("attributes").and_then(|v| v.as_array()) {
+        for attr in attrs {
+            if let (Some(key), Some(value)) = (
+                attr.get("key").and_then(|v| v.as_str()),
+                attr.get("value"),
+            ) {
+                let val_str = extract_otlp_value(value);
+                attributes.push((key.to_string(), val_str));
+            }
+        }
+    }
+
+    Some(CliSpan {
+        span_id,
+        parent_span_id,
+        name,
+        start_time_ns,
+        end_time_ns,
+        attributes,
+        children: Vec::new(),
+    })
+}
+
+fn extract_otlp_value(v: &serde_json::Value) -> String {
+    if let Some(s) = v.get("stringValue").and_then(|v| v.as_str()) {
+        return s.to_string();
+    }
+    if let Some(s) = v.get("intValue").and_then(|v| v.as_str()) {
+        return s.to_string();
+    }
+    if let Some(n) = v.get("intValue").and_then(|v| v.as_i64()) {
+        return n.to_string();
+    }
+    if let Some(n) = v.get("doubleValue").and_then(|v| v.as_f64()) {
+        return n.to_string();
+    }
+    if let Some(b) = v.get("boolValue").and_then(|v| v.as_bool()) {
+        return b.to_string();
+    }
+    v.to_string()
+}
+
+fn build_tree(mut flat: Vec<CliSpan>) -> Vec<CliSpan> {
+    use std::collections::HashMap;
+
+    // Sort by start time
+    flat.sort_by_key(|s| s.start_time_ns);
+
+    // Index by span_id
+    let mut map: HashMap<String, CliSpan> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for span in flat {
+        order.push(span.span_id.clone());
+        map.insert(span.span_id.clone(), span);
+    }
+
+    // Collect parent-child relationships
+    let mut children_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut root_ids: Vec<String> = Vec::new();
+
+    for id in &order {
+        let span = map.get(id).unwrap();
+        if let Some(ref parent_id) = span.parent_span_id {
+            if map.contains_key(parent_id) {
+                children_map
+                    .entry(parent_id.clone())
+                    .or_default()
+                    .push(id.clone());
+            } else {
+                root_ids.push(id.clone());
+            }
+        } else {
+            root_ids.push(id.clone());
+        }
+    }
+
+    // Build tree recursively
+    fn assemble(
+        id: &str,
+        map: &mut HashMap<String, CliSpan>,
+        children_map: &HashMap<String, Vec<String>>,
+    ) -> Option<CliSpan> {
+        let mut span = map.remove(id)?;
+        if let Some(child_ids) = children_map.get(id) {
+            for cid in child_ids {
+                if let Some(child) = assemble(cid, map, children_map) {
+                    span.children.push(child);
+                }
+            }
+            span.children.sort_by_key(|c| c.start_time_ns);
+        }
+        Some(span)
+    }
+
+    let mut roots = Vec::new();
+    for id in &root_ids {
+        if let Some(root) = assemble(id, &mut map, &children_map) {
+            roots.push(root);
+        }
+    }
+    roots.sort_by_key(|r| r.start_time_ns);
+    roots
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Formatting helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn format_duration_ns(ns: i64) -> String {
+    if ns <= 0 {
+        return "0ms".to_string();
+    }
+    let ms = ns as f64 / 1_000_000.0;
+    if ms < 1.0 {
+        return "<1ms".to_string();
+    }
+    if ms < 1000.0 {
+        return format!("{}ms", ms.round() as i64);
+    }
+    let secs = ms / 1000.0;
+    if secs < 60.0 {
+        return format!("{:.1}s", secs);
+    }
+    let mins = (secs / 60.0).floor() as i64;
+    let remaining_secs = (secs - (mins as f64 * 60.0)).round() as i64;
+    if mins < 60 {
+        if remaining_secs > 0 {
+            return format!("{}m {}s", mins, remaining_secs);
+        }
+        return format!("{}m", mins);
+    }
+    let hours = mins / 60;
+    let remaining_mins = mins % 60;
+    if remaining_mins > 0 {
+        format!("{}h {}m", hours, remaining_mins)
+    } else {
+        format!("{}h", hours)
+    }
+}
+
+fn format_tokens(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn format_cost(c: f64) -> String {
+    if c <= 0.0 {
+        return String::new();
+    }
+    if c < 0.001 {
+        format!("${:.6}", c)
+    } else if c < 0.01 {
+        format!("${:.4}", c)
+    } else {
+        format!("${:.2}", c)
+    }
+}
+
+fn term_width() -> usize {
+    terminal::size().map(|(w, _)| w as usize).unwrap_or(100)
+}
+
+fn separator(width: usize) -> String {
+    "─".repeat(width)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trace list display
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub async fn print_trace_list(client: &Distri, limit: i64) {
+    match client.list_traces(Some(limit)).await {
+        Ok(traces) => {
+            if traces.is_empty() {
+                println!("No traces found.");
+                return;
+            }
+            let width = term_width().min(90);
+            println!();
+            println!(
+                "  {}{}Traces{} ({} found)",
+                COLOR_BOLD,
+                COLOR_BRIGHT_GREEN,
+                COLOR_RESET,
+                traces.len()
+            );
+            println!("  {}{}{}", COLOR_GRAY, separator(width - 2), COLOR_RESET);
+            println!();
+
+            for trace in &traces {
+                print_trace_summary(trace, width);
+            }
+            println!(
+                "  {}{}{}\n",
+                COLOR_GRAY,
+                separator(width - 2),
+                COLOR_RESET
+            );
+            println!(
+                "  {}Use `distri traces show <trace-id>` to view details{}",
+                COLOR_GRAY, COLOR_RESET
+            );
+            println!();
+        }
+        Err(e) => {
+            eprintln!("Failed to list traces: {}", e);
+        }
+    }
+}
+
+fn print_trace_summary(trace: &TraceSummary, _width: usize) {
+    let duration = format_duration_ns(trace.end_time_ns - trace.start_time_ns);
+    let cost = format_cost(trace.total_cost);
+    let tokens = if trace.input_tokens > 0 {
+        format!("{}tokens", format_tokens(trace.input_tokens))
+    } else {
+        String::new()
+    };
+    let models: Vec<&str> = trace
+        .models
+        .iter()
+        .filter_map(|m| m.as_deref())
+        .collect();
+    let model_str = if models.is_empty() {
+        String::new()
+    } else {
+        models.join(", ")
+    };
+
+    // Line 1: name + stats
+    let trace_id_short = if trace.trace_id.len() > 10 {
+        &trace.trace_id[..10]
+    } else {
+        &trace.trace_id
+    };
+
+    println!(
+        "  {}{}{} {}  {}{}  {}{}  {}{}",
+        COLOR_BOLD,
+        trace.name,
+        COLOR_RESET,
+        format!(
+            "{}{} spans{}",
+            COLOR_GRAY, trace.span_count, COLOR_RESET
+        ),
+        COLOR_BRIGHT_CYAN,
+        duration,
+        COLOR_BRIGHT_YELLOW,
+        cost,
+        COLOR_GRAY,
+        COLOR_RESET,
+    );
+
+    // Line 2: trace ID, thread, tokens, models
+    let thread_str = trace
+        .thread_id
+        .as_deref()
+        .map(|t| {
+            let short = if t.len() > 8 { &t[..8] } else { t };
+            format!(" · {}", short)
+        })
+        .unwrap_or_default();
+    println!(
+        "  {}{}{}{}  {}{}  {}{}{}",
+        COLOR_GRAY,
+        trace_id_short,
+        thread_str,
+        COLOR_RESET,
+        COLOR_GRAY,
+        tokens,
+        COLOR_DIM,
+        model_str,
+        COLOR_RESET,
+    );
+
+    // Line 3: input preview (if any)
+    if let Some(ref preview) = trace.input_preview {
+        let trimmed = preview.trim();
+        if !trimmed.is_empty() {
+            let display = if trimmed.len() > 80 {
+                format!("{}...", &trimmed[..80])
+            } else {
+                trimmed.to_string()
+            };
+            println!("  {}{}{}", COLOR_DIM, display, COLOR_RESET);
+        }
+    }
+
+    println!();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trace detail (Gantt chart)
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub async fn print_trace_detail(client: &Distri, id: &str, span_filter: Option<&str>) {
+    // Try as trace_id first, then as thread_id
+    let otlp = match client.get_spans(Some(id), None).await {
+        Ok(v) => {
+            // Check if we got spans
+            let has_spans = v
+                .get("resourceSpans")
+                .and_then(|rs| rs.as_array())
+                .map(|a| !a.is_empty())
+                .unwrap_or(false);
+            if has_spans {
+                v
+            } else {
+                // Try as thread_id
+                match client.get_spans(None, Some(id)).await {
+                    Ok(v2) => v2,
+                    Err(_) => v, // Use original empty response
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to get spans: {}", e);
+            return;
+        }
+    };
+
+    let roots = parse_otlp_spans(&otlp);
+    if roots.is_empty() {
+        println!("No spans found for '{}'.", id);
+        return;
+    }
+
+    // Find time range across all spans
+    let (min_start, max_end) = find_time_range(&roots);
+    let total_span_count = count_spans(&roots);
+
+    let width = term_width().min(120);
+    let bar_width = width.saturating_sub(40).max(20);
+
+    // Header
+    let root_name = roots.first().map(|r| r.name.as_str()).unwrap_or("trace");
+    let root_duration = format_duration_ns(max_end - min_start);
+
+    // Collect aggregate stats
+    let (total_tokens, total_cost) = aggregate_stats(&roots);
+
+    let id_short = if id.len() > 16 { &id[..16] } else { id };
+
+    println!();
+    println!(
+        "  {}{}Trace: {}{} {}({}){}\n  {}{} spans · {} · {}tokens · {}{}",
+        COLOR_BOLD,
+        COLOR_BRIGHT_GREEN,
+        root_name,
+        COLOR_RESET,
+        COLOR_GRAY,
+        id_short,
+        COLOR_RESET,
+        COLOR_GRAY,
+        total_span_count,
+        root_duration,
+        format_tokens(total_tokens),
+        format_cost(total_cost),
+        COLOR_RESET,
+    );
+    println!("  {}{}{}", COLOR_GRAY, separator(width - 2), COLOR_RESET);
+    println!();
+
+    // Render Gantt chart
+    for root in &roots {
+        render_span_row(root, 0, min_start, max_end, bar_width, span_filter);
+    }
+
+    println!("  {}{}{}", COLOR_GRAY, separator(width - 2), COLOR_RESET);
+
+    // Print input/output for root span
+    if let Some(root) = roots.first() {
+        let input = root.input_value();
+        let output = root.output_value();
+
+        if input.is_some() || output.is_some() {
+            println!();
+        }
+
+        if let Some(inp) = input {
+            let display = truncate_text(inp, 300);
+            println!(
+                "  {}{}INPUT:{}",
+                COLOR_BOLD, COLOR_BRIGHT_BLUE, COLOR_RESET
+            );
+            for line in display.lines() {
+                println!("  {}{}{}", COLOR_DIM, line, COLOR_RESET);
+            }
+            println!();
+        }
+
+        if let Some(out) = output {
+            let display = truncate_text(out, 300);
+            println!(
+                "  {}{}OUTPUT:{}",
+                COLOR_BOLD, COLOR_BRIGHT_GREEN, COLOR_RESET
+            );
+            for line in display.lines() {
+                println!("  {}{}{}", COLOR_DIM, line, COLOR_RESET);
+            }
+            println!();
+        }
+    }
+}
+
+fn render_span_row(
+    span: &CliSpan,
+    depth: usize,
+    min_start: i64,
+    max_end: i64,
+    bar_width: usize,
+    span_filter: Option<&str>,
+) {
+    // If filtering, check if this span matches
+    if let Some(filter) = span_filter {
+        let filter_lower = filter.to_lowercase();
+        let matches = span.span_id.to_lowercase().contains(&filter_lower)
+            || span.name.to_lowercase().contains(&filter_lower)
+            || span.clean_title().to_lowercase().contains(&filter_lower);
+        if !matches {
+            // Still recurse into children
+            for child in &span.children {
+                render_span_row(child, depth, min_start, max_end, bar_width, span_filter);
+            }
+            return;
+        }
+    }
+
+    let cat = span.category();
+    let indent = "  ".repeat(depth + 1);
+    let title = span.clean_title();
+    let duration = format_duration_ns(span.duration_ns());
+
+    // Build info parts
+    let mut info_parts: Vec<String> = Vec::new();
+
+    if let Some(tokens) = span.input_tokens() {
+        if tokens > 0 {
+            info_parts.push(format!("{}{}↑{}", COLOR_GRAY, format_tokens(tokens), COLOR_RESET));
+        }
+    }
+    if let Some(cost) = span.cost() {
+        if cost > 0.0 {
+            info_parts.push(format!(
+                "{}{}{}",
+                COLOR_BRIGHT_YELLOW,
+                format_cost(cost),
+                COLOR_RESET
+            ));
+        }
+    }
+
+    let info_str = if info_parts.is_empty() {
+        String::new()
+    } else {
+        format!("  {}", info_parts.join("  "))
+    };
+
+    // Category badge
+    let badge = format!(
+        "{}[{}]{}",
+        cat.color(),
+        cat.label(),
+        COLOR_RESET
+    );
+
+    // Span row: indent + badge + title + info + duration
+    println!(
+        "{}{} {}{}{}  {}{}{}",
+        indent, badge, COLOR_BOLD, title, COLOR_RESET, info_str, COLOR_BRIGHT_CYAN, "",
+    );
+
+    // Right-align duration on same conceptual line - print on next sub-line with bar
+    // Calculate timeline bar
+    let total_range = max_end - min_start;
+    if total_range > 0 {
+        let start_pct = (span.start_time_ns - min_start) as f64 / total_range as f64;
+        let width_pct = span.duration_ns() as f64 / total_range as f64;
+
+        let bar_start = (start_pct * bar_width as f64) as usize;
+        let bar_len = (width_pct * bar_width as f64).max(1.0) as usize;
+        let bar_end = bar_width.saturating_sub(bar_start + bar_len);
+
+        let empty_char = "░";
+        let fill_char = cat.bar_char();
+
+        let bar = format!(
+            "{}{}{}{}{}{}",
+            COLOR_DIM,
+            empty_char.repeat(bar_start),
+            cat.color(),
+            fill_char.repeat(bar_len),
+            COLOR_DIM,
+            empty_char.repeat(bar_end),
+        );
+
+        let bar_indent = "  ".repeat(depth + 1);
+        let badge_space = " ".repeat(cat.label().len() + 3); // [XXX] + space
+        println!(
+            "{}{}{}{} {}{}{}",
+            bar_indent, badge_space, bar, COLOR_RESET, COLOR_BRIGHT_CYAN, duration, COLOR_RESET,
+        );
+    }
+
+    // Recurse into children
+    for child in &span.children {
+        render_span_row(child, depth + 1, min_start, max_end, bar_width, span_filter);
+    }
+}
+
+fn find_time_range(spans: &[CliSpan]) -> (i64, i64) {
+    let mut min_start = i64::MAX;
+    let mut max_end = i64::MIN;
+
+    fn walk(span: &CliSpan, min: &mut i64, max: &mut i64) {
+        if span.start_time_ns < *min {
+            *min = span.start_time_ns;
+        }
+        if span.end_time_ns > *max {
+            *max = span.end_time_ns;
+        }
+        for child in &span.children {
+            walk(child, min, max);
+        }
+    }
+
+    for span in spans {
+        walk(span, &mut min_start, &mut max_end);
+    }
+
+    if min_start == i64::MAX {
+        (0, 1)
+    } else {
+        (min_start, max_end)
+    }
+}
+
+fn count_spans(spans: &[CliSpan]) -> usize {
+    fn walk(span: &CliSpan) -> usize {
+        1 + span.children.iter().map(walk).sum::<usize>()
+    }
+    spans.iter().map(walk).sum()
+}
+
+fn aggregate_stats(spans: &[CliSpan]) -> (i64, f64) {
+    fn walk(span: &CliSpan, tokens: &mut i64, cost: &mut f64) {
+        if let Some(t) = span.input_tokens() {
+            *tokens += t;
+        }
+        if let Some(c) = span.cost() {
+            *cost += c;
+        }
+        for child in &span.children {
+            walk(child, tokens, cost);
+        }
+    }
+
+    let mut tokens = 0i64;
+    let mut cost = 0.0f64;
+    for span in spans {
+        walk(span, &mut tokens, &mut cost);
+    }
+    (tokens, cost)
+}
+
+fn truncate_text(text: &str, max_len: usize) -> String {
+    // Clean up whitespace and strip [external_tools: ...] suffix
+    let cleaned = text
+        .trim()
+        .lines()
+        .take(10)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if cleaned.len() > max_len {
+        format!("{}...", &cleaned[..max_len])
+    } else {
+        cleaned
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub async fn handle_traces_command(client: &Distri, command: TracesCommands) -> Result<()> {
+    match command {
+        TracesCommands::List { limit } => {
+            print_trace_list(client, limit).await;
+        }
+        TracesCommands::Show { id, span } => {
+            print_trace_detail(client, &id, span.as_deref()).await;
+        }
+    }
+    Ok(())
+}

--- a/distri-formatter/src/lib.rs
+++ b/distri-formatter/src/lib.rs
@@ -150,6 +150,23 @@ pub trait SurfaceRenderer: Send + Sync {
     fn supports_rich_text(&self) -> bool;
     fn max_message_length(&self) -> Option<usize>;
 
+    // --- Structured content ---
+    /// Structured content rendering hook for downstream crates.
+    ///
+    /// Receives the tool name (e.g. `render_card`, `ask_follow_up`) and its
+    /// JSON input. Downstream crates override this to produce channel-specific
+    /// rich output (inline keyboards, interactive messages, etc.).
+    ///
+    /// Returns `RendererOutput::None` by default — plain-text surfaces ignore
+    /// structured content and let the agent's text response serve as fallback.
+    fn render_structured(
+        &mut self,
+        _tool_name: &str,
+        _data: &serde_json::Value,
+    ) -> RendererOutput {
+        RendererOutput::None
+    }
+
     // --- Output ---
     /// Take any pending output. Returns `RendererOutput::None` if nothing is ready.
     fn take_output(&mut self) -> RendererOutput;

--- a/distri-types/src/agent.rs
+++ b/distri-types/src/agent.rs
@@ -894,6 +894,12 @@ pub enum ModelProvider {
         api_key: Option<String>,
         project_id: Option<String>,
     },
+    #[serde(rename = "alibaba_cloud")]
+    AlibabaCloud {
+        #[serde(default = "ModelProvider::alibaba_cloud_base_url")]
+        base_url: String,
+        api_key: Option<String>,
+    },
 }
 /// Defines the secret requirements for a provider
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1014,6 +1020,10 @@ impl ModelProvider {
         "2024-06-01".to_string()
     }
 
+    pub fn alibaba_cloud_base_url() -> String {
+        "https://dashscope-intl.aliyuncs.com/compatible-mode/v1".to_string()
+    }
+
     /// Returns the provider type enum for this provider.
     pub fn provider_type(&self) -> crate::models::ProviderType {
         match self {
@@ -1027,6 +1037,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => crate::models::ProviderType::AzureAiFoundry,
             ModelProvider::AwsBedrock { .. } => crate::models::ProviderType::AwsBedrock,
             ModelProvider::GoogleVertex { .. } => crate::models::ProviderType::GoogleVertex,
+            ModelProvider::AlibabaCloud { .. } => crate::models::ProviderType::AlibabaCloud,
         }
     }
 
@@ -1041,6 +1052,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => "azure_ai_foundry",
             ModelProvider::AwsBedrock { .. } => "aws_bedrock",
             ModelProvider::GoogleVertex { .. } => "google_vertex",
+            ModelProvider::AlibabaCloud { .. } => "alibaba_cloud",
         }
     }
 
@@ -1097,6 +1109,13 @@ impl ModelProvider {
                     vec!["GOOGLE_VERTEX_API_KEY"]
                 }
             }
+            ModelProvider::AlibabaCloud { api_key, .. } => {
+                if api_key.is_some() {
+                    vec![]
+                } else {
+                    vec!["DASHSCOPE_API_KEY"]
+                }
+            }
         }
     }
 
@@ -1136,6 +1155,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => "Azure AI Foundry",
             ModelProvider::AwsBedrock { .. } => "AWS Bedrock",
             ModelProvider::GoogleVertex { .. } => "Google Vertex AI",
+            ModelProvider::AlibabaCloud { .. } => "Alibaba Cloud",
         }
     }
 
@@ -1151,6 +1171,7 @@ impl ModelProvider {
             ModelProvider::AzureAiFoundry { .. } => "azure.ai.inference",
             ModelProvider::AwsBedrock { .. } => "aws.bedrock",
             ModelProvider::GoogleVertex { .. } => "gcp.vertex_ai",
+            ModelProvider::AlibabaCloud { .. } => "alibaba_cloud",
         }
     }
 }
@@ -1247,6 +1268,10 @@ impl ModelSettings {
                 base_url: String::new(),
                 api_key: None,
                 project_id: None,
+            },
+            "alibaba_cloud" => ModelProvider::AlibabaCloud {
+                base_url: ModelProvider::alibaba_cloud_base_url(),
+                api_key: None,
             },
             _ if provider_str.starts_with("custom_") => ModelProvider::OpenAICompatible {
                 base_url: String::new(),

--- a/distri-types/src/default_models.json
+++ b/distri-types/src/default_models.json
@@ -752,6 +752,45 @@
         }
       ],
       "models": []
+    },
+    {
+      "id": "alibaba_cloud",
+      "label": "Alibaba Cloud",
+      "keys": [
+        {
+          "key": "DASHSCOPE_API_KEY",
+          "label": "API key",
+          "placeholder": "sk-...",
+          "required": true,
+          "sensitive": true
+        }
+      ],
+      "models": [
+        {
+          "id": "qwen3.6-plus",
+          "name": "Qwen3.6 Plus",
+          "capability": "completion",
+          "context_window": 1000000,
+          "pricing": {
+            "type": "completion",
+            "input": 0.276,
+            "output": 1.651,
+            "cached_input": 0.028
+          }
+        },
+        {
+          "id": "qwen3.5-35b-a3b",
+          "name": "Qwen3.5 35B A3B",
+          "capability": "completion",
+          "context_window": 262144,
+          "pricing": {
+            "type": "completion",
+            "input": 0.16,
+            "output": 1.30,
+            "cached_input": 0.016
+          }
+        }
+      ]
     }
   ]
 }

--- a/distri-types/src/models.rs
+++ b/distri-types/src/models.rs
@@ -16,6 +16,7 @@ pub enum ProviderType {
     AzureAiFoundry,
     AwsBedrock,
     GoogleVertex,
+    AlibabaCloud,
     #[serde(rename = "elevenlabs")]
     ElevenLabs,
     /// User-defined provider (LangDB-compatible / OpenAI-compatible)
@@ -33,6 +34,7 @@ impl ProviderType {
             Self::AzureAiFoundry => "azure_ai_foundry",
             Self::AwsBedrock => "aws_bedrock",
             Self::GoogleVertex => "google_vertex",
+            Self::AlibabaCloud => "alibaba_cloud",
             Self::ElevenLabs => "elevenlabs",
             Self::Custom(id) => id.as_str(),
         }
@@ -47,6 +49,7 @@ impl ProviderType {
             Self::AzureAiFoundry => "Azure AI Foundry",
             Self::AwsBedrock => "AWS Bedrock",
             Self::GoogleVertex => "Google Vertex AI",
+            Self::AlibabaCloud => "Alibaba Cloud",
             Self::ElevenLabs => "ElevenLabs",
             Self::Custom(id) => id.as_str(),
         }
@@ -61,6 +64,7 @@ impl ProviderType {
             "azure_ai_foundry" => Self::AzureAiFoundry,
             "aws_bedrock" => Self::AwsBedrock,
             "google_vertex" => Self::GoogleVertex,
+            "alibaba_cloud" => Self::AlibabaCloud,
             "elevenlabs" => Self::ElevenLabs,
             other => Self::Custom(other.to_string()),
         }

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -192,8 +192,18 @@ impl Distri {
     }
 
     pub async fn register_agent(&self, definition: &StandardDefinition) -> Result<(), ClientError> {
+        let config =
+            distri_types::configuration::AgentConfig::StandardAgent(definition.clone());
+        self.register_agent_config(&config).await
+    }
+
+    /// Register any agent type (standard or workflow) from a typed `AgentConfig`.
+    pub async fn register_agent_config(
+        &self,
+        config: &distri_types::configuration::AgentConfig,
+    ) -> Result<(), ClientError> {
         let create_url = format!("{}/agents", self.base_url);
-        let resp = self.http.post(&create_url).json(definition).send().await?;
+        let resp = self.http.post(&create_url).json(config).send().await?;
         if resp.status().is_success() {
             return Ok(());
         }

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -2054,6 +2054,30 @@ pub struct NewSecretRequest {
     pub value: String,
 }
 
+// ========== Traces API ==========
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceSummary {
+    pub trace_id: String,
+    pub name: String,
+    pub start_time_ns: i64,
+    pub end_time_ns: i64,
+    pub span_count: i64,
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    #[serde(default)]
+    pub input_tokens: i64,
+    #[serde(default)]
+    pub total_cost: f64,
+    #[serde(default)]
+    pub step_count: i64,
+    #[serde(default)]
+    pub models: Vec<Option<String>>,
+    #[serde(default)]
+    pub input_preview: Option<String>,
+}
+
 // ========== Threads API ==========
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -2585,6 +2609,63 @@ impl Distri {
             .collect();
 
         Ok(items)
+    }
+
+    // ========== Traces API ==========
+
+    pub async fn list_traces(
+        &self,
+        limit: Option<i64>,
+    ) -> Result<Vec<TraceSummary>, ClientError> {
+        let mut url = format!("{}/traces", self.base_url);
+        if let Some(limit) = limit {
+            url = format!("{}?limit={}", url, limit);
+        }
+        let resp = self.http.get(&url).send().await?;
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ClientError::InvalidResponse(format!(
+                "failed to list traces: {}",
+                text
+            )));
+        }
+        let body: serde_json::Value = resp.json().await?;
+        let arr = if let Some(traces) = body.get("traces") {
+            traces.clone()
+        } else {
+            body
+        };
+        serde_json::from_value(arr)
+            .map_err(|e| ClientError::InvalidResponse(format!("failed to parse traces: {}", e)))
+    }
+
+    pub async fn get_spans(
+        &self,
+        trace_id: Option<&str>,
+        thread_id: Option<&str>,
+    ) -> Result<serde_json::Value, ClientError> {
+        let mut params = vec![];
+        if let Some(tid) = trace_id {
+            params.push(format!("trace_id={}", tid));
+        }
+        if let Some(tid) = thread_id {
+            params.push(format!("thread_id={}", tid));
+        }
+        let url = if params.is_empty() {
+            format!("{}/spans", self.base_url)
+        } else {
+            format!("{}/spans?{}", self.base_url, params.join("&"))
+        };
+        let resp = self.http.get(&url).send().await?;
+        if resp.status().is_success() {
+            Ok(resp.json().await?)
+        } else {
+            let text = resp.text().await.unwrap_or_default();
+            Err(ClientError::InvalidResponse(format!(
+                "failed to get spans: {}",
+                text
+            )))
+        }
     }
 
     // ========== Workflows API ==========

--- a/distri/src/lib.rs
+++ b/distri/src/lib.rs
@@ -24,7 +24,8 @@ pub use client::{
     Distri, InvokeOptions, LlmExecuteOptions, LlmExecuteResponse, LoginUrlResponse,
     NewPromptTemplateRequest, NewSecretRequest, PluginResponse, PluginsListResponse,
     PromptTemplateResponse, ProviderInfo, SecretEntry, SkillListItemResponse, SkillResponse,
-    SyncPromptTemplatesResponse, TaskNamespaceResponse, ThreadSummary, TtsModelsResponse,
+    SyncPromptTemplatesResponse, TaskNamespaceResponse, ThreadSummary, TraceSummary,
+    TtsModelsResponse,
     TtsSpeechRequest, TtsSpeechResponse, UpdatePluginRequest, UpdateSkillRequest,
     ValidatePluginResponse, WorkspaceResponse,
 };

--- a/server/distri-core/model_pricing.json
+++ b/server/distri-core/model_pricing.json
@@ -18,7 +18,9 @@
     "gemini-2.5-flash": { "input": 0.15, "output": 0.60, "cached_input": 0.0375 },
     "gemini-2.0-flash": { "input": 0.10, "output": 0.40, "cached_input": 0.025 },
     "deepseek-chat": { "input": 0.27, "output": 1.10, "cached_input": 0.07 },
-    "deepseek-reasoner": { "input": 0.55, "output": 2.19, "cached_input": 0.14 }
+    "deepseek-reasoner": { "input": 0.55, "output": 2.19, "cached_input": 0.14 },
+    "qwen3.6-plus": { "input": 0.276, "output": 1.651, "cached_input": 0.028 },
+    "qwen3.5-35b-a3b": { "input": 0.16, "output": 1.30, "cached_input": 0.016 }
   },
   "_comment": "Prices in USD per 1M tokens. cached_input is the price for cache-read input tokens."
 }

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -14,7 +14,23 @@ use crate::{
 use async_trait::async_trait;
 use distri_types::configuration::WorkflowAgentDefinition;
 use distri_workflow::*;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+/// Typed input envelope for workflow agent invocation.
+///
+/// Workflow-control fields (entry_point) are parsed explicitly;
+/// everything else is forwarded as the workflow's user input via `#[serde(flatten)]`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkflowInput {
+    /// Optional entry point ID to start the workflow from a specific step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entry_point: Option<String>,
+
+    /// All remaining fields are forwarded as workflow user input.
+    #[serde(flatten)]
+    pub data: serde_json::Value,
+}
 
 /// A workflow-based agent that executes a workflow DAG.
 #[derive(Clone, Debug)]
@@ -389,31 +405,31 @@ impl WorkflowAgent {
                 AgentError::Execution(format!("Invalid workflow definition: {}", e))
             })?;
 
-        // Extract input from message (first text part as JSON, or empty)
-        let input = message
+        // Parse typed input from message (first text part as JSON, or defaults)
+        let workflow_input: WorkflowInput = message
             .parts
             .iter()
             .find_map(|p| {
                 if let distri_types::Part::Text(text) = p {
-                    serde_json::from_str::<serde_json::Value>(text).ok()
+                    serde_json::from_str::<WorkflowInput>(text).ok()
                 } else {
                     None
                 }
             })
-            .unwrap_or(serde_json::json!({}));
+            .unwrap_or_default();
 
         // Save user message to thread (like StandardAgent does)
         context.save_message(&message).await;
 
-        // Validate and merge input
+        // Validate and merge the user data (everything except workflow control fields)
         workflow = workflow
-            .with_input(input.clone())
+            .with_input(workflow_input.data)
             .map_err(|e| AgentError::Validation(e))?;
 
-        // Apply entry point if specified in input (e.g. {"_entry_point": "grade_only"})
-        if let Some(entry_id) = input.get("_entry_point").and_then(|v| v.as_str()) {
+        // Apply entry point if specified
+        if let Some(entry_id) = workflow_input.entry_point {
             workflow = workflow
-                .apply_entry_point(entry_id)
+                .apply_entry_point(&entry_id)
                 .map_err(|e| AgentError::Validation(e))?;
         }
 

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -410,6 +410,13 @@ impl WorkflowAgent {
             .with_input(input.clone())
             .map_err(|e| AgentError::Validation(e))?;
 
+        // Apply entry point if specified in input (e.g. {"_entry_point": "grade_only"})
+        if let Some(entry_id) = input.get("_entry_point").and_then(|v| v.as_str()) {
+            workflow = workflow
+                .apply_entry_point(entry_id)
+                .map_err(|e| AgentError::Validation(e))?;
+        }
+
         // Populate env namespace from executor context env vars
         if let Some(ctx_obj) = workflow.context.as_object_mut() {
             let env = ctx_obj

--- a/server/distri-core/src/agent/workflow_agent.rs
+++ b/server/distri-core/src/agent/workflow_agent.rs
@@ -246,20 +246,158 @@ impl StepExecutor for ContextStepExecutor {
                 Ok(StepResult::done(serde_json::json!({"message": message})))
             }
 
-            StepKind::Script { command, .. } => Ok(StepResult::done(serde_json::json!({
-                "deferred": true,
-                "command": command,
-                "message": "Script execution not yet wired to shell"
-            }))),
+            StepKind::Script {
+                command,
+                args,
+                cwd,
+                env,
+                timeout_secs,
+                shell,
+                ..
+            } => {
+                // Resolve templates in command and args
+                let resolved_command = resolve_template(command, wf_context);
+                let resolved_args: Vec<String> =
+                    args.iter().map(|a| resolve_template(a, wf_context)).collect();
+
+                // Build process: use shell wrapper or direct command
+                let mut cmd = match shell {
+                    Some(ShellType::Bash) | None => {
+                        let mut c = tokio::process::Command::new("bash");
+                        c.arg("-c");
+                        if resolved_args.is_empty() {
+                            c.arg(&resolved_command);
+                        } else {
+                            c.arg(format!(
+                                "{} {}",
+                                resolved_command,
+                                resolved_args.join(" ")
+                            ));
+                        }
+                        c
+                    }
+                    Some(ShellType::Sh) => {
+                        let mut c = tokio::process::Command::new("sh");
+                        c.arg("-c");
+                        c.arg(&resolved_command);
+                        c
+                    }
+                    Some(ShellType::Zsh) => {
+                        let mut c = tokio::process::Command::new("zsh");
+                        c.arg("-c");
+                        c.arg(&resolved_command);
+                        c
+                    }
+                };
+
+                if let Some(dir) = cwd {
+                    cmd.current_dir(resolve_template(dir, wf_context));
+                }
+                if let Some(envs) = env {
+                    for (k, v) in envs {
+                        cmd.env(k, resolve_template(v, wf_context));
+                    }
+                }
+
+                // Inject workflow context as WORKFLOW_CONTEXT env var so scripts can read it
+                cmd.env(
+                    "WORKFLOW_CONTEXT",
+                    serde_json::to_string(wf_context).unwrap_or_default(),
+                );
+
+                let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(60));
+                let output = tokio::time::timeout(timeout, cmd.output())
+                    .await
+                    .map_err(|_| {
+                        format!(
+                            "Script '{}' timed out after {}s",
+                            step.id,
+                            timeout.as_secs()
+                        )
+                    })?
+                    .map_err(|e| format!("Script '{}' failed to start: {}", step.id, e))?;
+
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+                // Emit stdout/stderr as text events for observability
+                if !stdout.is_empty() {
+                    self.context
+                        .emit(WorkflowAgent::emit_text(&format!(
+                            "```\n{}\n```\n",
+                            stdout.trim()
+                        )))
+                        .await;
+                }
+                if !stderr.is_empty() {
+                    self.context
+                        .emit(WorkflowAgent::emit_text(&format!(
+                            "⚠ stderr: {}\n",
+                            stderr.trim()
+                        )))
+                        .await;
+                }
+
+                if output.status.success() {
+                    // Try parsing stdout as JSON for structured results
+                    let result = serde_json::from_str::<serde_json::Value>(stdout.trim())
+                        .unwrap_or_else(|_| serde_json::json!({"output": stdout.trim()}));
+                    Ok(StepResult::done(result))
+                } else {
+                    let code = output.status.code().unwrap_or(-1);
+                    Ok(StepResult::failed(&format!(
+                        "Exit code {}: {}",
+                        code,
+                        if stderr.is_empty() {
+                            stdout.trim().to_string()
+                        } else {
+                            stderr.trim().to_string()
+                        }
+                    )))
+                }
+            }
 
             StepKind::AgentRun {
                 agent_id, prompt, ..
-            } => Ok(StepResult::done(serde_json::json!({
-                "deferred": true,
-                "agent_id": agent_id,
-                "prompt": prompt,
-                "message": "Agent delegation not yet wired"
-            }))),
+            } => {
+                let resolved_prompt = resolve_template(prompt, wf_context);
+
+                let sub_message = crate::types::Message {
+                    role: distri_types::MessageRole::User,
+                    parts: vec![distri_types::Part::Text(resolved_prompt.clone())],
+                    ..Default::default()
+                };
+
+                let Some(orchestrator) = self.context.orchestrator.as_ref() else {
+                    return Ok(StepResult::failed(
+                        "No orchestrator available for agent delegation",
+                    ));
+                };
+
+                // Create a child context with its own event channel so sub-agent
+                // events don't interleave with workflow events.
+                let (tx, mut rx) = tokio::sync::mpsc::channel(10000);
+                let sub_ctx = Arc::new(self.context.clone_with_tx(tx));
+                let drain = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+                let result = orchestrator
+                    .execute_stream(agent_id, sub_message, sub_ctx, None)
+                    .await;
+                let _ = drain.await;
+
+                match result {
+                    Ok(invoke_result) => {
+                        let output = invoke_result.content.unwrap_or_default();
+                        let result = serde_json::from_str::<serde_json::Value>(&output)
+                            .unwrap_or_else(|_| serde_json::json!({"output": output}));
+                        Ok(StepResult::done(result))
+                    }
+                    Err(e) => Ok(StepResult::failed(&format!(
+                        "Agent '{}' failed: {}",
+                        agent_id, e
+                    ))),
+                }
+            }
 
             StepKind::Condition { expression, .. } => Ok(StepResult::done(serde_json::json!({
                 "expression": expression,
@@ -284,7 +422,10 @@ impl StepExecutor for ContextStepExecutor {
     }
 
     fn supports(&self, requirement: &StepRequirement) -> bool {
-        matches!(requirement.skill.as_str(), "native:network" | "native:tool")
+        matches!(
+            requirement.skill.as_str(),
+            "native:network" | "native:tool" | "native:shell" | "native:agent"
+        )
     }
 }
 

--- a/server/distri-core/src/llm.rs
+++ b/server/distri-core/src/llm.rs
@@ -1551,7 +1551,8 @@ pub fn create_llm_executor(
         | ModelProvider::Gemini { .. }
         | ModelProvider::AzureAiFoundry { .. }
         | ModelProvider::AwsBedrock { .. }
-        | ModelProvider::GoogleVertex { .. } => {
+        | ModelProvider::GoogleVertex { .. }
+        | ModelProvider::AlibabaCloud { .. } => {
             let resolved = ms.inner.api_format.resolve(&ms.model);
             if resolved == distri_types::ResolvedOpenAiApiFormat::Responses {
                 Ok(Box::new(

--- a/server/distri-core/src/openai_responses_llm.rs
+++ b/server/distri-core/src/openai_responses_llm.rs
@@ -130,6 +130,16 @@ impl OpenAIResponsesLLMExecutor {
                 let url_with_version = format!("{}?api-version={}", azure_base, api_version);
                 (url_with_version, String::new()) // Empty api_key since we use header
             }
+            ModelProvider::AlibabaCloud { base_url, api_key } => {
+                let key = if let Some(key) = api_key {
+                    key.clone()
+                } else {
+                    secret_resolver
+                        .resolve_or_empty("DASHSCOPE_API_KEY")
+                        .await
+                };
+                (base_url.clone(), key)
+            }
             other => {
                 return Err(AgentError::InvalidConfiguration(format!(
                     "OpenAI Responses API format is not supported for {:?} provider",

--- a/server/llm-gateway/src/provider_config.rs
+++ b/server/llm-gateway/src/provider_config.rs
@@ -114,6 +114,15 @@ impl From<&ModelProvider> for ProviderClientConfig {
                 query_params: vec![],
                 send_api_key_header: true,
             },
+            ModelProvider::AlibabaCloud { base_url, api_key } => Self {
+                base_url: base_url.clone(),
+                api_key_secret: "DASHSCOPE_API_KEY",
+                inline_api_key: api_key.clone(),
+                project_id: None,
+                extra_headers: HashMap::new(),
+                query_params: vec![],
+                send_api_key_header: false,
+            },
         }
     }
 }
@@ -255,6 +264,7 @@ mod tests {
             ("azure_ai_foundry", "AZURE_AI_FOUNDRY_API_KEY"),
             ("aws_bedrock", "AWS_ACCESS_KEY_ID"),
             ("google_vertex", "GOOGLE_VERTEX_API_KEY"),
+            ("alibaba_cloud", "DASHSCOPE_API_KEY"),
         ];
         for (provider_str, expected_secret) in cases {
             let ms = distri_types::ModelSettings::from_provider_model_str(&format!(


### PR DESCRIPTION
## Summary

- Add render_structured() hook to SurfaceRenderer trait
- Support entry points in WorkflowAgent invocation
- Typed WorkflowInput with serde flatten, add register_agent_config
- Wire up Script and AgentRun step execution in WorkflowAgent
- Add CLI traces command with Gantt chart visualization
- Add Alibaba Cloud provider with Qwen3.6 Plus and Qwen3.5 35B A3B models
- Update distrijs submodule