### PR TITLE
Refactor A2A streaming handlers to separate prep and execution

### DIFF
--- a/distri-a2a/src/a2a_types.rs
+++ b/distri-a2a/src/a2a_types.rs
@@ -256,6 +256,28 @@ pub struct JsonRpcResponse {
     pub id: Option<serde_json::Value>,
 }
 
+impl JsonRpcResponse {
+    /// Build a successful JSON-RPC response.
+    pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+
+    /// Build an error JSON-RPC response.
+    pub fn error(id: Option<serde_json::Value>, err: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            result: None,
+            error: Some(err),
+            id,
+        }
+    }
+}
+
 /// A JSON-RPC error object.
 #[derive(Serialize, Debug)]
 pub struct JsonRpcError {
@@ -263,6 +285,32 @@ pub struct JsonRpcError {
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcError {
+    /// Build a JSON-RPC error with just a code and message.
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// JSON-RPC "Invalid params" error (code -32602).
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(-32602, message)
+    }
+
+    /// JSON-RPC "Method not found" error (code -32601).
+    pub fn method_not_found(message: impl Into<String>) -> Self {
+        Self::new(-32601, message)
+    }
+
+    /// JSON-RPC "Internal error" (code -32603).
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(-32603, message)
+    }
 }
 
 // A2A Method Params

--- a/server/distri-core/src/a2a/handler.rs
+++ b/server/distri-core/src/a2a/handler.rs
@@ -1,5 +1,7 @@
-use crate::a2a::stream::handle_message_send_streaming_sse;
-use crate::a2a::{unimplemented_error, A2AError, SseMessage};
+use crate::a2a::stream::{
+    prepare_resubscribe, prepare_streaming_session, run_resubscribe_stream, run_streaming_session,
+};
+use crate::a2a::{agent_error_to_jsonrpc, unimplemented_error, A2AError, SseMessage};
 use crate::agent::types::ExecutorContextMetadata;
 use crate::agent::AgentOrchestrator;
 use crate::types::default_agent_version;
@@ -14,7 +16,7 @@ type BoxedSseStream = std::pin::Pin<
     >,
 >;
 
-use distri_a2a::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, MessageSendParams, TaskIdParams};
+use distri_a2a::{JsonRpcRequest, JsonRpcResponse, MessageSendParams, TaskIdParams};
 use distri_types::configuration::DefinitionOverrides;
 use futures::future::Either;
 use serde_json::Value;
@@ -238,21 +240,29 @@ impl A2AHandler {
                 {
                     ctx.default_model_settings = Some(ms.clone());
                 }
-                let executor_context = executor_context;
-                match executor_context {
-                    Ok(executor_context) => {
-                        let res = handle_message_send_streaming_sse(
+
+                let prep = match executor_context {
+                    Ok(ctx) => {
+                        prepare_streaming_session(
                             req_id.clone(),
                             agent_id.clone(),
                             req.params,
                             self.executor.clone(),
-                            Arc::new(executor_context),
+                            Arc::new(ctx),
                         )
-                        .await;
-
-                        Either::Left(Box::pin(res) as BoxedSseStream)
+                        .await
                     }
-                    Err(e) => Either::Right(Err(e)),
+                    Err(e) => Err(e),
+                };
+
+                // Preflight errors for `message/stream` must come back as an SSE
+                // frame (the client opens `Accept: text/event-stream` and parses
+                // the response as SSE). Emit a one-shot error frame stream.
+                match prep {
+                    Ok(session) => {
+                        Either::Left(Box::pin(run_streaming_session(session)) as BoxedSseStream)
+                    }
+                    Err(e) => Either::Left(single_error_frame_stream(req_id.clone(), e)),
                 }
             }
             "message/send" => {
@@ -293,27 +303,20 @@ impl A2AHandler {
             "tasks/cancel" => Either::Right(self.handle_task_cancel(req.params).await),
             "tasks/resubscribe" => {
                 // Subscribe to events for an existing task via broadcaster (always available).
-                let params: TaskIdParams = match serde_json::from_value(req.params) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return Either::Right(JsonRpcResponse {
-                            jsonrpc: "2.0".to_string(),
-                            result: None,
-                            error: Some(map_agent_error(AgentError::Validation(format!(
-                                "Invalid params: {}",
-                                e
-                            )))),
-                            id: req_id.clone(),
-                        });
-                    }
-                };
-                let res = crate::a2a::stream::handle_resubscribe_sse(
-                    req_id.clone(),
-                    params.id,
-                    self.executor.clone(),
-                )
+                let prep = async {
+                    let params: TaskIdParams = serde_json::from_value(req.params)
+                        .map_err(|e| AgentError::Validation(format!("Invalid params: {e}")))?;
+                    prepare_resubscribe(params.id, self.executor.clone()).await
+                }
                 .await;
-                Either::Left(Box::pin(res) as BoxedSseStream)
+
+                match prep {
+                    Ok(event_stream) => Either::Left(
+                        Box::pin(run_resubscribe_stream(req_id.clone(), event_stream))
+                            as BoxedSseStream,
+                    ),
+                    Err(e) => Either::Left(single_error_frame_stream(req_id.clone(), e)),
+                }
             }
             "agent/authenticatedExtendedCard"
             | "tasks/pushNotificationConfig/set"
@@ -328,18 +331,13 @@ impl A2AHandler {
 
         match result {
             Either::Left(res) => Either::Left(res),
-            Either::Right(Ok(res)) => Either::Right(JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                result: Some(res),
-                error: None,
-                id: req_id.clone(),
-            }),
-            Either::Right(Err(err)) => Either::Right(JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                result: None,
-                error: Some(map_agent_error(err)),
-                id: req_id.clone(),
-            }),
+            Either::Right(Ok(res)) => {
+                Either::Right(JsonRpcResponse::success(req_id.clone(), res))
+            }
+            Either::Right(Err(err)) => Either::Right(JsonRpcResponse::error(
+                req_id.clone(),
+                agent_error_to_jsonrpc(&err),
+            )),
         }
     }
 
@@ -446,13 +444,19 @@ impl A2AHandler {
     }
 }
 
-pub fn map_agent_error(e: AgentError) -> JsonRpcError {
-    JsonRpcError {
-        code: -32603,
-        message: e.to_string(),
-        data: None,
-    }
+/// Build a one-shot SSE stream that yields a single JSON-RPC error frame.
+/// Used for preflight failures on `message/stream` and `tasks/resubscribe`
+/// where the HTTP response has already committed to `text/event-stream`.
+fn single_error_frame_stream(
+    req_id: Option<serde_json::Value>,
+    err: AgentError,
+) -> BoxedSseStream {
+    let frame = SseMessage::error_frame(req_id, agent_error_to_jsonrpc(&err));
+    Box::pin(futures_util::stream::once(async move {
+        Ok::<_, std::convert::Infallible>(frame)
+    }))
 }
+
 
 pub fn validate_message(message: &crate::types::Message) -> Result<(), AgentError> {
     if message.parts.is_empty() {

--- a/server/distri-core/src/a2a/mod.rs
+++ b/server/distri-core/src/a2a/mod.rs
@@ -1,6 +1,9 @@
 mod handler;
 pub mod stream;
-use distri_a2a::{EventKind, JsonRpcError, Message, Part, Role, TaskStatus, TaskStatusUpdateEvent};
+use distri_a2a::{
+    EventKind, JsonRpcError, JsonRpcResponse, Message, Part, Role, TaskStatus,
+    TaskStatusUpdateEvent,
+};
 use distri_types::{a2a_converters::MessageMetadata, AgentError};
 pub use handler::A2AHandler;
 use serde::{Deserialize, Serialize};
@@ -45,6 +48,46 @@ impl SseMessage {
             data: serde_json::to_string(&self).unwrap(),
         }
     }
+
+    /// Serialize a JSON-RPC response into an SSE `data:` frame.
+    pub fn from_jsonrpc(resp: &JsonRpcResponse) -> Self {
+        Self {
+            event: None,
+            data: serde_json::to_string(resp).unwrap_or_default(),
+        }
+    }
+
+    /// Convenience: build a success frame from a serializable result value.
+    pub fn success_frame(
+        id: Option<serde_json::Value>,
+        result: impl Serialize,
+    ) -> Self {
+        let result = serde_json::to_value(result).unwrap_or_default();
+        Self::from_jsonrpc(&JsonRpcResponse::success(id, result))
+    }
+
+    /// Convenience: build an error frame from a JSON-RPC error.
+    pub fn error_frame(id: Option<serde_json::Value>, err: JsonRpcError) -> Self {
+        Self::from_jsonrpc(&JsonRpcResponse::error(id, err))
+    }
+}
+
+impl From<&JsonRpcResponse> for SseMessage {
+    fn from(r: &JsonRpcResponse) -> Self {
+        Self::from_jsonrpc(r)
+    }
+}
+
+/// Map an `AgentError` into a JSON-RPC error, selecting an appropriate code
+/// based on the variant. (Can't be a `From` impl due to the orphan rule —
+/// both types live in foreign crates.)
+pub fn agent_error_to_jsonrpc(err: &AgentError) -> JsonRpcError {
+    let code = match err {
+        AgentError::Validation(_) => -32602,
+        AgentError::NotImplemented(_) => -32601,
+        _ => -32603,
+    };
+    JsonRpcError::new(code, err.to_string())
 }
 
 pub fn to_a2a_message(message: &distri_types::Message, task: &distri_types::Task) -> Message {

--- a/server/distri-core/src/a2a/stream.rs
+++ b/server/distri-core/src/a2a/stream.rs
@@ -1,9 +1,9 @@
 use crate::a2a::handler::validate_message;
 use crate::a2a::mapper::{map_agent_event, map_final_result};
-use crate::agent::InvokeResult;
 use crate::a2a::{extract_text_from_message, SseMessage};
+use crate::agent::InvokeResult;
 use crate::agent::{
-    types::ExecutorContextMetadata, AgentEventType, AgentOrchestrator, ExecutorContext,
+    types::ExecutorContextMetadata, AgentEvent, AgentEventType, AgentOrchestrator, ExecutorContext,
 };
 use crate::secrets::SecretResolver;
 use crate::AgentError;
@@ -11,10 +11,11 @@ use distri_auth::context::{with_user_and_workspace, with_user_id};
 // Note: with_user_and_workspace IS needed for stream! macro and spawned tasks
 // because they don't inherit task-local storage from middleware
 use anyhow::anyhow;
-use distri_a2a::{JsonRpcError, JsonRpcResponse, MessageSendParams};
+use distri_a2a::MessageSendParams;
 use distri_types::configuration::{AgentConfig, DefinitionOverrides};
 
 use futures_util::future::poll_fn;
+use futures_util::stream::BoxStream;
 use futures_util::Stream;
 use std::future::Future;
 use std::pin::Pin;
@@ -149,47 +150,32 @@ pub async fn init_thread_get_message(
 
 /// Subscribe to events for an existing task via the broadcaster.
 /// Used by the `tasks/resubscribe` A2A method.
-pub async fn handle_resubscribe_sse(
-    req_id: Option<serde_json::Value>,
+///
+/// Returns the event stream on success; the caller is responsible for converting
+/// errors into a JSON-RPC response (see `handler.rs`).
+pub async fn prepare_resubscribe(
     task_id: String,
     executor: Arc<AgentOrchestrator>,
+) -> Result<BoxStream<'static, AgentEvent>, AgentError> {
+    executor
+        .broadcaster()
+        .subscribe(&task_id)
+        .await
+        .map_err(|e| AgentError::Session(format!("Failed to subscribe: {e}")))
+}
+
+/// Run the broadcaster event loop for a `tasks/resubscribe` session.
+pub fn run_resubscribe_stream(
+    req_id: Option<serde_json::Value>,
+    event_stream: BoxStream<'static, AgentEvent>,
 ) -> impl futures_util::stream::Stream<Item = Result<SseMessage, std::convert::Infallible>> {
     async_stream::stream! {
-        // Subscribe via broadcaster (always available via runtime)
-        let event_stream = match executor.broadcaster().subscribe(&task_id).await {
-            Ok(s) => s,
-            Err(e) => {
-                let error = distri_a2a::JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    result: None,
-                    error: Some(distri_a2a::JsonRpcError {
-                        code: -32603,
-                        message: format!("Failed to subscribe: {}", e),
-                        data: None,
-                    }),
-                    id: req_id.clone(),
-                };
-                yield Ok::<_, std::convert::Infallible>(SseMessage {
-                    event: None,
-                    data: serde_json::to_string(&error).unwrap_or_default(),
-                });
-                return;
-            }
-        };
-
         futures_util::pin_mut!(event_stream);
         while let Some(event) = futures_util::StreamExt::next(&mut event_stream).await {
             let msg = map_agent_event(&event);
-            let response = distri_a2a::JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                result: Some(serde_json::to_value(&msg).unwrap_or_default()),
-                error: None,
-                id: req_id.clone(),
-            };
-            yield Ok::<_, std::convert::Infallible>(SseMessage {
-                event: None,
-                data: serde_json::to_string(&response).unwrap_or_default(),
-            });
+            yield Ok::<_, std::convert::Infallible>(
+                SseMessage::success_frame(req_id.clone(), msg),
+            );
         }
     }
 }
@@ -337,251 +323,147 @@ fn spawn_background_execution(
     }));
 }
 
-pub async fn handle_message_send_streaming_sse(
+/// A fully-prepared streaming session: background execution has been spawned
+/// and the broadcaster has been subscribed. Yielding from the event stream is
+/// now infallible from the handler's perspective.
+pub struct StreamingSession {
+    pub req_id: Option<serde_json::Value>,
+    pub user_id: String,
+    pub executor_context: Arc<ExecutorContext>,
+    pub event_stream: BoxStream<'static, AgentEvent>,
+}
+
+/// Prepare a `message/stream` session end-to-end:
+/// parse params → validate secrets → init thread → prepare execution context →
+/// register task → spawn relay → spawn background execution → subscribe.
+///
+/// All fallible work happens here so the caller can render a single JSON-RPC
+/// error frame instead of weaving error branches through the event loop.
+pub async fn prepare_streaming_session(
     req_id: Option<serde_json::Value>,
     agent_id: String,
     params: serde_json::Value,
     executor: Arc<AgentOrchestrator>,
     executor_context: Arc<ExecutorContext>,
-) -> impl futures_util::stream::Stream<Item = Result<SseMessage, std::convert::Infallible>> {
+) -> Result<StreamingSession, AgentError> {
     let user_id = executor_context.user_id.clone();
-    let stream_user_id = user_id.clone();
     let workspace_id = executor_context
         .workspace_id
         .as_ref()
         .and_then(|s| uuid::Uuid::parse_str(s).ok());
-    let stream_workspace_id = workspace_id;
-    let id_field_clone = executor_context.session_id.clone();
 
-    // Validate provider secrets BEFORE entering the stream! macro,
-    // because stream! doesn't inherit task-local storage (user/workspace context)
-    // needed by TenantSecretStore.
-    let secret_validation = validate_provider_secrets(&executor, &agent_id).await;
+    let params: MessageSendParams = serde_json::from_value(params)
+        .map_err(|e| AgentError::Validation(format!("Invalid params: {e}")))?;
+
+    // Validate provider secrets before we touch anything else. This runs in the
+    // caller's task-local context (user/workspace) so TenantSecretStore works.
+    validate_provider_secrets(&executor, &agent_id).await?;
+
+    // init_thread_get_message and prepare_execution are called from the calling
+    // task, which already has user/workspace task-locals from the HTTP middleware.
+    let (thread_id, message) = init_thread_get_message(
+        agent_id.clone(),
+        executor.clone(),
+        &params,
+        executor_context.clone(),
+    )
+    .await?;
+
+    let (exec_ctx, definition_overrides) =
+        prepare_execution(&agent_id, &params, &executor, &executor_context).await?;
+
+    let main_task_id = exec_ctx.task_id.clone();
+
+    // Register task — wire cancellation signal + mailbox into context.
+    let (executor_context_arc, event_rx) = executor
+        .register_task(&main_task_id, &thread_id, exec_ctx)
+        .await
+        .map_err(|e| AgentError::Session(format!("Failed to register task: {e}")))?;
+
+    // Spawn event relay: agent events → broadcaster.
+    executor.spawn_task_relay(main_task_id.clone(), event_rx);
+
+    // Spawn background execution. Client disconnect does NOT kill the agent —
+    // execution continues in the background.
+    spawn_background_execution(
+        executor.clone(),
+        agent_id.clone(),
+        message,
+        executor_context_arc,
+        Some(definition_overrides),
+        main_task_id.clone(),
+        user_id.clone(),
+        workspace_id,
+    );
+
+    // Subscribe to broadcaster events — the event stream the caller will consume.
+    let event_stream = executor
+        .broadcaster()
+        .subscribe(&main_task_id)
+        .await
+        .map_err(|e| AgentError::Session(format!("Failed to subscribe to task events: {e}")))?;
+
+    Ok(StreamingSession {
+        req_id,
+        user_id,
+        executor_context,
+        event_stream,
+    })
+}
+
+/// Run a prepared streaming session: relay broadcaster events as SSE frames
+/// until a terminal event, then yield a final `MessageKind::Message` if the
+/// agent set a final result.
+pub fn run_streaming_session(
+    session: StreamingSession,
+) -> impl futures_util::stream::Stream<Item = Result<SseMessage, std::convert::Infallible>> {
+    let StreamingSession {
+        req_id,
+        user_id,
+        executor_context,
+        event_stream,
+    } = session;
 
     let stream = async_stream::stream! {
-        let user_id = stream_user_id.clone();
-        let params: MessageSendParams = match serde_json::from_value(params) {
-            Ok(p) => p,
-            Err(e) => {
-                let error = JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32602,
-                        message: e.to_string(),
-                        data: None,
-                    }),
-                    id: Some(id_field_clone.clone().into()),
-                };
-                yield Ok::<_, std::convert::Infallible>(SseMessage {
-                    event: None,
-                    data: serde_json::to_string(&error).unwrap(),
-                });
-                return;
+        futures_util::pin_mut!(event_stream);
+        let mut saw_terminal = false;
+        while let Some(event) = futures_util::StreamExt::next(&mut event_stream).await {
+            let is_terminal = matches!(
+                &event.event,
+                AgentEventType::RunFinished { .. } | AgentEventType::RunError { .. }
+            );
+            let msg = map_agent_event(&event);
+            yield Ok::<_, std::convert::Infallible>(
+                SseMessage::success_frame(req_id.clone(), msg),
+            );
+            if is_terminal {
+                saw_terminal = true;
+                break;
             }
-        };
-
-        // Check the pre-computed secret validation result
-        if let Err(e) = secret_validation {
-            let error = JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                result: None,
-                error: Some(JsonRpcError {
-                    code: -32603,
-                    message: e.to_string(),
-                    data: None,
-                }),
-                id: Some(id_field_clone.clone().into()),
-            };
-            yield Ok::<_, std::convert::Infallible>(SseMessage {
-                event: None,
-                data: serde_json::to_string(&error).unwrap(),
-            });
-            return;
         }
 
-        // stream! macro doesn't inherit task-local storage, so wrap here
-        let (thread_id, message) = match with_user_and_workspace(
-            user_id.clone(),
-            stream_workspace_id,
-            init_thread_get_message(
-                agent_id.clone(),
-                executor.clone(),
-                &params,
-                executor_context.clone(),
-            )
-        )
-        .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                let error = JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32603,
-                        message: e.to_string(),
-                        data: None,
-                    }),
-                    id: Some(id_field_clone.clone().into()),
+        // After terminal event: read the final result from the shared
+        // ExecutorContext (set by the `final` tool via set_final_result, and
+        // shared via Arc<RwLock>) and yield it as MessageKind::Message so
+        // clients render the final answer.
+        if saw_terminal {
+            if let Some(final_value) = executor_context.get_final_result().await {
+                let text = match final_value {
+                    serde_json::Value::String(s) => s,
+                    other => other.to_string(),
                 };
-                yield Ok::<_, std::convert::Infallible>(SseMessage {
-                    event: None,
-                    data: serde_json::to_string(&error).unwrap(),
-                });
-                return;
-            }
-        };
-
-        // Prepare execution context with metadata, browser, overrides
-        let (exec_ctx, definition_overrides) = match prepare_execution(
-            &agent_id, &params, &executor, &executor_context,
-        ).await {
-            Ok(v) => v,
-            Err(e) => {
-                let error = JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32603,
-                        message: e.to_string(),
-                        data: None,
-                    }),
-                    id: Some(id_field_clone.clone().into()),
-                };
-                yield Ok::<_, std::convert::Infallible>(SseMessage {
-                    event: None,
-                    data: serde_json::to_string(&error).unwrap(),
-                });
-                return;
-            }
-        };
-
-        let main_task_id = exec_ctx.task_id.clone();
-
-        // === Background execution: register → relay → spawn → subscribe ===
-        // Client disconnect does NOT kill the agent — execution continues in background.
-
-        // 1. Register task — wire cancellation signal + mailbox into context
-        let (executor_context_arc, event_rx) = match executor
-            .register_task(&main_task_id, &thread_id, exec_ctx)
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                let error = JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32603,
-                        message: format!("Failed to register task: {}", e),
-                        data: None,
-                    }),
-                    id: req_id.clone(),
-                };
-                yield Ok::<_, std::convert::Infallible>(SseMessage {
-                    event: None,
-                    data: serde_json::to_string(&error).unwrap(),
-                });
-                return;
-            }
-        };
-
-        // 2. Spawn event relay: agent events → broadcaster
-        executor.spawn_task_relay(main_task_id.clone(), event_rx);
-
-        // 3. Spawn background execution
-        spawn_background_execution(
-            executor.clone(),
-            agent_id.clone(),
-            message,
-            executor_context_arc,
-            Some(definition_overrides),
-            main_task_id.clone(),
-            user_id.clone(),
-            workspace_id,
-        );
-
-        // 4. Subscribe to broadcaster events and stream as SSE.
-        //    Break the loop when a terminal event is seen, then yield a final
-        //    MessageKind::Message constructed from the task's saved final message.
-        let executor_context_for_final = executor_context.clone();
-        match executor.broadcaster().subscribe(&main_task_id).await {
-            Ok(event_stream) => {
-                futures_util::pin_mut!(event_stream);
-                let mut saw_terminal = false;
-                while let Some(event) = futures_util::StreamExt::next(&mut event_stream).await {
-                    let is_terminal = matches!(
-                        &event.event,
-                        AgentEventType::RunFinished { .. } | AgentEventType::RunError { .. }
-                    );
-                    let msg = map_agent_event(&event);
-                    let message = JsonRpcResponse {
-                        jsonrpc: "2.0".to_string(),
-                        result: Some(serde_json::to_value(msg).unwrap_or_default()),
-                        error: None,
-                        id: req_id.clone(),
+                if !text.is_empty() {
+                    let result = InvokeResult {
+                        content: Some(text),
+                        ..Default::default()
                     };
-                    yield Ok::<_, std::convert::Infallible>(SseMessage {
-                        event: None,
-                        data: serde_json::to_string(&message).unwrap_or_default(),
-                    });
-                    if is_terminal {
-                        saw_terminal = true;
-                        break;
-                    }
+                    let msg = map_final_result(&result, executor_context.clone());
+                    yield Ok::<_, std::convert::Infallible>(
+                        SseMessage::success_frame(req_id.clone(), msg),
+                    );
                 }
-
-                // After terminal event: read the final result from the shared
-                // ExecutorContext (set by the `final` tool via set_final_result, and
-                // shared via Arc<RwLock>) and yield it as MessageKind::Message so
-                // clients render the final answer.
-                if saw_terminal {
-                    if let Some(final_value) =
-                        executor_context_for_final.get_final_result().await
-                    {
-                        let text = match final_value {
-                            serde_json::Value::String(s) => s,
-                            other => other.to_string(),
-                        };
-                        if !text.is_empty() {
-                            let result = InvokeResult {
-                                content: Some(text),
-                                ..Default::default()
-                            };
-                            let msg = map_final_result(&result, executor_context_for_final);
-                            let message = JsonRpcResponse {
-                                jsonrpc: "2.0".to_string(),
-                                result: Some(serde_json::to_value(msg).unwrap_or_default()),
-                                error: None,
-                                id: req_id.clone(),
-                            };
-                            yield Ok::<_, std::convert::Infallible>(SseMessage {
-                                event: None,
-                                data: serde_json::to_string(&message).unwrap_or_default(),
-                            });
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                let error = JsonRpcResponse {
-                    jsonrpc: "2.0".to_string(),
-                    result: None,
-                    error: Some(JsonRpcError {
-                        code: -32603,
-                        message: format!("Failed to subscribe to task events: {}", e),
-                        data: None,
-                    }),
-                    id: req_id.clone(),
-                };
-                yield Ok::<_, std::convert::Infallible>(SseMessage {
-                    event: None,
-                    data: serde_json::to_string(&error).unwrap(),
-                });
             }
         }
-
     };
 
     UserScopedStream::new(user_id, Box::pin(stream))


### PR DESCRIPTION
## Summary
Refactor the A2A streaming request handlers (`message/stream` and `tasks/resubscribe`) to separate preflight validation and setup from the event loop execution. This improves error handling, code clarity, and testability by moving all fallible work outside the `async_stream::stream!` macro.

## Key Changes

- **Split `handle_message_send_streaming_sse` into two functions:**
  - `prepare_streaming_session()`: Performs all preflight work (param validation, secret validation, thread init, execution context setup, task registration, relay spawning, broadcaster subscription) and returns a `StreamingSession` struct on success
  - `run_streaming_session()`: Consumes the prepared session and runs the event loop, now infallible from the handler's perspective

- **Split `handle_resubscribe_sse` into two functions:**
  - `prepare_resubscribe()`: Validates the task ID and subscribes to the broadcaster
  - `run_resubscribe_stream()`: Runs the event loop with the prepared stream

- **Updated `handler.rs` to use the new split functions:**
  - Calls `prepare_*` functions before entering the SSE response path
  - Converts preflight errors into single-frame error SSE streams via new `single_error_frame_stream()` helper
  - Uses new `agent_error_to_jsonrpc()` helper for consistent error code mapping

- **Added convenience methods to `JsonRpcResponse` and `JsonRpcError`:**
  - `JsonRpcResponse::success()` and `JsonRpcResponse::error()` builders
  - `JsonRpcError::new()`, `invalid_params()`, `method_not_found()`, `internal()` constructors

- **Added convenience methods to `SseMessage`:**
  - `success_frame()` and `error_frame()` builders for common patterns
  - `from_jsonrpc()` for serializing JSON-RPC responses into SSE frames

- **Introduced `StreamingSession` struct** to encapsulate the prepared state (req_id, user_id, executor_context, event_stream)

## Implementation Details

- Preflight work now runs in the caller's task-local context (with user/workspace context from HTTP middleware), ensuring `TenantSecretStore` and other context-dependent operations work correctly
- Error handling is simplified: all preflight errors are caught before the stream is created, eliminating nested error branches in the event loop
- The event loop is now purely about consuming events and formatting them as SSE frames, with no error handling logic
- Imports cleaned up: removed unused `JsonRpcError` and `JsonRpcResponse` from `stream.rs` where they're no longer needed

https://claude.ai/code/session_01PjWPv8q3Ej6FfwjgusodcH