### PR TITLE
Add background task execution and task resubscription support

### DIFF
--- a/distri-cli/src/chat.rs
+++ b/distri-cli/src/chat.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 use anyhow::Result;
 use crossterm::terminal;
 use distri::{
-    print_stream_with_health, AgentStreamClient, BuildHttpClient, ContextHealth, Distri,
-    DistriClientApp, DistriConfig,
+    print_resubscribe_with_health, print_stream_with_health_ex, AgentStreamClient, BuildHttpClient,
+    ContextHealth, Distri, DistriClientApp, DistriConfig,
 };
 use distri_types::configuration::AgentConfig;
 use inquire::Select;
@@ -417,6 +417,304 @@ pub async fn handle_slash_command(
     }
 }
 
+/// Run a streaming agent call and handle Ctrl-C cancellation.
+///
+/// Semantics:
+/// - While the stream is active, Ctrl-C calls `tasks/cancel` on the
+///   current task (if its id has been observed) and waits for the
+///   stream to end naturally as the backend publishes the Canceled
+///   terminal event.
+/// - A second Ctrl-C force-returns (control flow falls back to the
+///   prompt, where rustyline handles double-tap to exit the CLI).
+async fn stream_with_ctrl_c_cancel(
+    stream_client: &AgentStreamClient,
+    stream_agent_id: &str,
+    params: distri_a2a::MessageSendParams,
+    verbose: bool,
+    agent_display_name: String,
+    show_tools: bool,
+    shared_health: Arc<RwLock<ContextHealth>>,
+) -> Result<()> {
+    let task_id_sink: Arc<tokio::sync::Mutex<Option<String>>> =
+        Arc::new(tokio::sync::Mutex::new(None));
+
+    let stream_fut = print_stream_with_health_ex(
+        stream_client,
+        stream_agent_id,
+        params,
+        verbose,
+        Some(agent_display_name),
+        show_tools,
+        Some(shared_health),
+        Some(task_id_sink.clone()),
+    );
+    tokio::pin!(stream_fut);
+
+    let mut cancel_sent = false;
+    loop {
+        tokio::select! {
+            result = &mut stream_fut => {
+                return match result {
+                    Ok((_, Ok(()))) => Ok(()),
+                    Ok((_, Err(err))) => Err(err.into()),
+                    Err(err) => Err(err.into()),
+                };
+            }
+            _ = tokio::signal::ctrl_c() => {
+                if !cancel_sent {
+                    cancel_sent = true;
+                    let tid = task_id_sink.lock().await.clone();
+                    if let Some(tid) = tid {
+                        println!(
+                            "\n{}Cancelling task {}...{}",
+                            COLOR_GRAY, tid, COLOR_RESET
+                        );
+                        if let Err(e) = stream_client.cancel_task(stream_agent_id, &tid).await {
+                            eprintln!("Cancel failed: {}", e);
+                        }
+                    } else {
+                        println!(
+                            "\n{}Interrupted before task started — press Ctrl+C again to bail out{}",
+                            COLOR_GRAY, COLOR_RESET
+                        );
+                    }
+                    // Keep awaiting the stream so the terminal event
+                    // from the backend closes things cleanly.
+                    continue;
+                }
+                // Second Ctrl-C: give up waiting and return control.
+                println!(
+                    "\n{}Detaching from stream; task may still be finishing in background{}",
+                    COLOR_GRAY, COLOR_RESET
+                );
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// If the given thread has an active (non-terminal) task, resubscribe
+/// to its event stream and print remaining events. Used on `--resume`
+/// and `/resume` so reopening a thread mid-execution picks back up
+/// where the previous client left off.
+async fn reattach_if_active_task(
+    stream_client: &AgentStreamClient,
+    agent_id: &str,
+    thread_id: &str,
+    config: &DistriConfig,
+    verbose: bool,
+    agent_display_name: String,
+    show_tools: bool,
+    shared_health: Arc<RwLock<ContextHealth>>,
+) {
+    let distri = Distri::from_config(config.clone());
+    let thread = match distri.get_thread(thread_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::debug!("get_thread({}) failed: {}", thread_id, e);
+            return;
+        }
+    };
+    let Some(task_id) = thread.active_task_id.clone() else {
+        return;
+    };
+    println!(
+        "{}Task {} still running — reattaching...{}",
+        COLOR_GRAY, task_id, COLOR_RESET
+    );
+
+    // Wrap with the same Ctrl-C cancel semantics so the user can stop
+    // a resumed background task with one Ctrl-C just like a fresh one.
+    let task_id_sink = Arc::new(tokio::sync::Mutex::new(Some(task_id.clone())));
+    let resubscribe_fut = print_resubscribe_with_health(
+        stream_client,
+        agent_id,
+        &task_id,
+        verbose,
+        Some(agent_display_name),
+        show_tools,
+        Some(shared_health),
+    );
+    tokio::pin!(resubscribe_fut);
+
+    let mut cancel_sent = false;
+    loop {
+        tokio::select! {
+            result = &mut resubscribe_fut => {
+                match result {
+                    Ok((_, Ok(()))) => {}
+                    Ok((_, Err(err))) => eprintln!("Resubscribe error: {}", err),
+                    Err(err) => eprintln!("Resubscribe error: {}", err),
+                }
+                return;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                if !cancel_sent {
+                    cancel_sent = true;
+                    if let Some(tid) = task_id_sink.lock().await.clone() {
+                        println!(
+                            "\n{}Cancelling task {}...{}",
+                            COLOR_GRAY, tid, COLOR_RESET
+                        );
+                        if let Err(e) = stream_client.cancel_task(agent_id, &tid).await {
+                            eprintln!("Cancel failed: {}", e);
+                        }
+                    }
+                    continue;
+                }
+                println!(
+                    "\n{}Detaching; task may still be finishing in background{}",
+                    COLOR_GRAY, COLOR_RESET
+                );
+                return;
+            }
+        }
+    }
+}
+
+/// Send one message and exit as soon as we have a task_id, leaving the
+/// task running on the server. Used by `--background`.
+///
+/// Prints `thread_id=… task_id=…` to stdout so callers (scripts,
+/// shells, tests) can capture them and reattach later via
+/// `distri chat --resume <thread_id>`.
+pub async fn run_background_send(
+    app: &mut DistriClientApp,
+    config: &DistriConfig,
+    agent_name: String,
+    message: String,
+    resume: Option<String>,
+    extra_tools: Vec<distri_types::dynamic_tool::DynamicToolFactory>,
+) -> Result<()> {
+    let thread_id = if let Some(ref resume_arg) = resume {
+        resolve_resume_arg(resume_arg)
+    } else {
+        uuid::Uuid::new_v4().to_string()
+    };
+
+    // Resolve the agent so tool registries and external-tool lists are set up.
+    let registry = app.registry();
+    register_approval_handler(&registry);
+    let workspace_path = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let tool_defs = register_all(&registry, &agent_name, &workspace_path);
+    app.add_tool_definitions(tool_defs);
+
+    let stream_config = config.clone().with_timeout(60);
+    let http_client = stream_config.build_http_client()?;
+    let initial_external: std::collections::HashSet<String> =
+        LOCAL_TOOL_NAMES.iter().map(|s| s.to_string()).collect();
+    let mut stream_client = AgentStreamClient::from_config(config.clone())
+        .with_http_client(http_client)
+        .with_tool_registry(registry)
+        .with_external_tool_names(initial_external);
+    for tool in extra_tools {
+        stream_client.register_dynamic_tool(tool);
+    }
+
+    let (stream_agent_id, external_tool_names) = match app.fetch_agent(&agent_name).await? {
+        Some(agent_cfg) => {
+            let id = agent_cfg.agent.get_name().to_string();
+            let mut ext_names = std::collections::HashSet::new();
+            if let AgentConfig::StandardAgent(def) = &agent_cfg.agent {
+                if let Some(tools) = &def.tools {
+                    if let Some(ext) = &tools.external {
+                        for name in ext {
+                            if name != "*" {
+                                ext_names.insert(name.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            for name in LOCAL_TOOL_NAMES {
+                ext_names.insert(name.to_string());
+            }
+            (id, ext_names)
+        }
+        None => {
+            anyhow::bail!("Agent '{}' not found", agent_name);
+        }
+    };
+    stream_client.set_external_tool_names(external_tool_names);
+
+    let distri_client = Distri::from_config(config.clone());
+    let connections_context = build_connections_context(&distri_client).await;
+    let mut params = build_message_params(
+        message,
+        Some(&thread_id),
+        None,
+        None,
+        connections_context,
+    );
+    app.inject_external_tools(&mut params);
+
+    // Fire the stream and stop as soon as we observe a task_id.
+    let task_id_cell: Arc<tokio::sync::Mutex<Option<String>>> =
+        Arc::new(tokio::sync::Mutex::new(None));
+    let task_id_cell_cb = task_id_cell.clone();
+
+    let stream_fut = stream_client.stream_agent(
+        &stream_agent_id,
+        params,
+        move |item: distri::StreamItem| {
+            let sink = task_id_cell_cb.clone();
+            async move {
+                if let Some(ev) = &item.agent_event {
+                    if !ev.task_id.is_empty() && ev.task_id != "unknown_task" {
+                        let mut g = sink.lock().await;
+                        if g.is_none() {
+                            *g = Some(ev.task_id.clone());
+                        }
+                    }
+                }
+            }
+        },
+    );
+    tokio::pin!(stream_fut);
+
+    // Poll the stream for up to 5 seconds, checking for a task_id.
+    let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            res = &mut stream_fut => {
+                // Stream finished before we even got a task id — unusual.
+                res.map_err(|e| anyhow::anyhow!("stream error: {}", e))?;
+                break;
+            }
+            _ = &mut deadline => {
+                // Give up waiting; exit regardless.
+                break;
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                if task_id_cell.lock().await.is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    let task_id = task_id_cell.lock().await.clone();
+    match task_id {
+        Some(tid) => {
+            println!("thread_id={}", thread_id);
+            println!("task_id={}", tid);
+            println!(
+                "Task is running in background. Reattach with: distri chat --resume {}",
+                thread_id
+            );
+            let _ = save_last_thread(&thread_id);
+            Ok(())
+        }
+        None => {
+            anyhow::bail!(
+                "Task did not produce a task_id within 5s; aborting background send"
+            );
+        }
+    }
+}
+
 pub async fn run_interactive_chat(
     app: &mut DistriClientApp,
     config: &DistriConfig,
@@ -471,6 +769,9 @@ pub async fn run_interactive_chat(
         print_thread_history(&history_client, &thread_id).await;
     }
 
+    // Build the stream client up-front so resume-time reattach and
+    // the main loop share the same instance.
+
     let rl_config = Config::builder()
         .auto_add_history(true)
         .bracketed_paste(true)
@@ -510,6 +811,23 @@ pub async fn run_interactive_chat(
 
     let mut last_interrupt: Option<Instant> = None;
     let shared_health: Arc<RwLock<ContextHealth>> = Arc::new(RwLock::new(ContextHealth::default()));
+
+    // If resuming a thread that still has a task running in the
+    // background on the server, reattach and stream remaining events
+    // before accepting new user input.
+    if resume.is_some() {
+        reattach_if_active_task(
+            &stream_client,
+            &current_agent,
+            &thread_id,
+            config,
+            verbose,
+            current_agent.clone(),
+            show_tools.load(Ordering::Relaxed),
+            shared_health.clone(),
+        )
+        .await;
+    }
 
     loop {
         {
@@ -582,6 +900,17 @@ pub async fn run_interactive_chat(
                     );
                     let history_client = Distri::from_config(config.clone());
                     print_thread_history(&history_client, &thread_id).await;
+                    reattach_if_active_task(
+                        &stream_client,
+                        &current_agent,
+                        &thread_id,
+                        config,
+                        verbose,
+                        current_agent.clone(),
+                        show_tools.load(Ordering::Relaxed),
+                        shared_health.clone(),
+                    )
+                    .await;
                     continue;
                 }
             }
@@ -635,21 +964,18 @@ pub async fn run_interactive_chat(
         );
         app.inject_external_tools(&mut params);
 
-        match print_stream_with_health(
+        let stream_result = stream_with_ctrl_c_cancel(
             &stream_client,
             &stream_agent_id,
             params,
             verbose,
-            Some(current_agent.clone()),
+            current_agent.clone(),
             show_tools.load(Ordering::Relaxed),
-            Some(shared_health.clone()),
+            shared_health.clone(),
         )
-        .await
-        {
-            Ok((_health, Ok(()))) => {}
-            Ok((_health, Err(err))) => {
-                eprintln!("Error from agent: {}", err);
-            }
+        .await;
+        match stream_result {
+            Ok(()) => {}
             Err(err) => {
                 eprintln!("Error from agent: {}", err);
             }

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -91,6 +91,12 @@ enum Commands {
         /// W3C traceparent header for distributed tracing (passed by SandboxLauncher).
         #[clap(long)]
         traceparent: Option<String>,
+        /// Fire-and-forget: send the task, print the resulting
+        /// thread_id/task_id, and exit while the task keeps running on
+        /// the server. Reattach later with `distri tui --resume
+        /// <thread_id>`.
+        #[clap(long)]
+        background: bool,
     },
 
     /// Agent-related commands (defaults to list)
@@ -498,9 +504,25 @@ async fn main() -> Result<()> {
             thread_id,
             remote,
             traceparent,
+            background,
         } => {
             let extra_tools = parse_cli_overrides(overrides.as_deref());
             let agent_name = agent.unwrap_or_else(|| "distri_runner".to_string());
+
+            // --background: send the task, capture thread_id/task_id,
+            // and exit while execution keeps running on the server.
+            if background {
+                chat::run_background_send(
+                    &mut app,
+                    &config,
+                    agent_name,
+                    task,
+                    resume,
+                    extra_tools,
+                )
+                .await?;
+                return Ok(());
+            }
             let mut external_tool_names = std::collections::HashSet::new();
             if let Some(agent_cfg) = app.fetch_agent(&agent_name).await? {
                 // Extract external tool names from agent definition

--- a/distri-types/src/core.rs
+++ b/distri-types/src/core.rs
@@ -629,6 +629,12 @@ pub struct Thread {
     /// Total tokens used across all runs in this thread
     #[serde(default)]
     pub total_tokens: u64,
+    /// ID of a task currently running in this thread (if any). Computed
+    /// at read time by querying the task store for non-terminal tasks;
+    /// never persisted. Used by clients to know whether to call
+    /// `tasks/resubscribe` when reopening a thread.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub active_task_id: Option<String>,
 }
 
 impl Thread {
@@ -656,6 +662,7 @@ impl Thread {
             input_tokens: 0,
             output_tokens: 0,
             total_tokens: 0,
+            active_task_id: None,
         }
     }
 

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -2613,6 +2613,30 @@ impl Distri {
 
     // ========== Threads API ==========
 
+    /// Fetch a single thread by id. The server enriches the response
+    /// with `active_task_id` for any task currently running in the
+    /// thread — clients use this to decide whether to call
+    /// `tasks/resubscribe` when reopening a conversation.
+    pub async fn get_thread(
+        &self,
+        thread_id: &str,
+    ) -> Result<Option<distri_types::Thread>, ClientError> {
+        let url = format!("{}/threads/{}", self.base_url, thread_id);
+        let resp = self.http.get(&url).send().await?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ClientError::InvalidResponse(format!(
+                "failed to get thread: {}",
+                text
+            )));
+        }
+        let thread: distri_types::Thread = resp.json().await?;
+        Ok(Some(thread))
+    }
+
     pub async fn list_threads(&self) -> Result<Vec<ThreadSummary>, ClientError> {
         let url = format!("{}/threads", self.base_url);
         let resp = self.http.get(&url).send().await?;

--- a/distri/src/client_stream.rs
+++ b/distri/src/client_stream.rs
@@ -162,6 +162,99 @@ impl AgentStreamClient {
         &self,
         agent_id: &str,
         params: MessageSendParams,
+        on_event: H,
+    ) -> Result<(), StreamError>
+    where
+        H: FnMut(StreamItem) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send,
+    {
+        let params = self.merge_registered_tools(params);
+
+        let rpc = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::Value::String(Uuid::new_v4().to_string())),
+            method: "message/stream".to_string(),
+            params: serde_json::to_value(params)?,
+        };
+
+        self.run_sse(agent_id, rpc, on_event).await
+    }
+
+    /// Resubscribe to an existing task's event stream via
+    /// `tasks/resubscribe`. Used to reattach when a previous SSE
+    /// connection was dropped but the task is still running in the
+    /// background on the server.
+    ///
+    /// Returns when the task emits a final event (or the server
+    /// synthesizes one for already-terminal tasks).
+    pub async fn resubscribe_task<H, Fut>(
+        &self,
+        agent_id: &str,
+        task_id: &str,
+        on_event: H,
+    ) -> Result<(), StreamError>
+    where
+        H: FnMut(StreamItem) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send,
+    {
+        let rpc = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::Value::String(Uuid::new_v4().to_string())),
+            method: "tasks/resubscribe".to_string(),
+            params: serde_json::json!({ "id": task_id }),
+        };
+
+        self.run_sse(agent_id, rpc, on_event).await
+    }
+
+    /// Cancel a running task via `tasks/cancel`. Idempotent on the
+    /// server: calling it on an already-terminal task returns the
+    /// current record without error.
+    pub async fn cancel_task(
+        &self,
+        agent_id: &str,
+        task_id: &str,
+    ) -> Result<(), StreamError> {
+        let url = format!(
+            "{}/agents/{}",
+            self.base_url.trim_end_matches('/'),
+            agent_id
+        );
+
+        let rpc = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::Value::String(Uuid::new_v4().to_string())),
+            method: "tasks/cancel".to_string(),
+            params: serde_json::json!({ "id": task_id }),
+        };
+
+        let resp = self
+            .http
+            .post(url)
+            .json(&rpc)
+            .send()
+            .await
+            .map_err(|e| StreamError::Event(format!("cancel request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StreamError::Server(format!(
+                "tasks/cancel failed ({status}): {body}"
+            )));
+        }
+        // Ignore body; status 200 with an error object is also
+        // treated as success since we use this fire-and-forget.
+        Ok(())
+    }
+
+    /// Shared SSE consumer: POSTs a JSON-RPC request to the agent
+    /// endpoint and forwards parsed `StreamItem`s to `on_event`.
+    /// Used by both `stream_agent` and `resubscribe_task`.
+    async fn run_sse<H, Fut>(
+        &self,
+        agent_id: &str,
+        rpc: JsonRpcRequest,
         mut on_event: H,
     ) -> Result<(), StreamError>
     where
@@ -173,15 +266,6 @@ impl AgentStreamClient {
             self.base_url.trim_end_matches('/'),
             agent_id
         );
-
-        let params = self.merge_registered_tools(params);
-
-        let rpc = JsonRpcRequest {
-            jsonrpc: "2.0".to_string(),
-            id: Some(serde_json::Value::String(Uuid::new_v4().to_string())),
-            method: "message/stream".to_string(),
-            params: serde_json::to_value(params)?,
-        };
 
         let resp = self
             .http

--- a/distri/src/lib.rs
+++ b/distri/src/lib.rs
@@ -38,7 +38,8 @@ pub use distri_types::{
     ModelProviderDefinition, ProviderKeyDefinition, ProviderType, TokenResponse, TtsVoiceInfo,
 };
 pub use printer::{
-    ContextHealth, EventPrinter, print_stream, print_stream_verbose, print_stream_with_health,
+    ContextHealth, EventPrinter, print_resubscribe_with_health, print_stream, print_stream_verbose,
+    print_stream_with_health, print_stream_with_health_ex,
 };
 
 #[cfg(test)]

--- a/distri/src/printer.rs
+++ b/distri/src/printer.rs
@@ -934,6 +934,10 @@ pub async fn print_stream_verbose(
 /// If `shared_health` is Some, updates it from budget events so the caller
 /// (e.g., the chat loop) can display context utilization in the status line.
 ///
+/// If `task_id_sink` is Some, the task_id from the first event that carries
+/// one is written into it. Callers use this to support Ctrl-C cancellation
+/// of a running task via `tasks/cancel`.
+///
 /// Returns (updated_health, stream_result).
 pub async fn print_stream_with_health(
     client: &AgentStreamClient,
@@ -943,6 +947,32 @@ pub async fn print_stream_with_health(
     agent_display_name: Option<String>,
     show_tools: bool,
     shared_health: Option<Arc<RwLock<ContextHealth>>>,
+) -> Result<(Arc<RwLock<ContextHealth>>, Result<(), StreamError>), StreamError> {
+    print_stream_with_health_ex(
+        client,
+        agent_id,
+        params,
+        verbose,
+        agent_display_name,
+        show_tools,
+        shared_health,
+        None,
+    )
+    .await
+}
+
+/// Extended variant of `print_stream_with_health` that also exposes the
+/// current task id to the caller via `task_id_sink`. Used by the CLI to
+/// cancel on Ctrl-C.
+pub async fn print_stream_with_health_ex(
+    client: &AgentStreamClient,
+    agent_id: &str,
+    params: MessageSendParams,
+    verbose: bool,
+    agent_display_name: Option<String>,
+    show_tools: bool,
+    shared_health: Option<Arc<RwLock<ContextHealth>>>,
+    task_id_sink: Option<Arc<Mutex<Option<String>>>>,
 ) -> Result<(Arc<RwLock<ContextHealth>>, Result<(), StreamError>), StreamError> {
     let mut printer = EventPrinter::new().with_verbose(verbose);
     if let Some(name) = agent_display_name {
@@ -959,6 +989,65 @@ pub async fn print_stream_with_health(
     let printer = Arc::new(Mutex::new(printer));
     let result = client
         .stream_agent(agent_id, params, {
+            let printer = printer.clone();
+            let task_id_sink = task_id_sink.clone();
+            move |item: StreamItem| {
+                let printer = printer.clone();
+                let task_id_sink = task_id_sink.clone();
+                async move {
+                    if let Some(event) = item.agent_event.clone() {
+                        if let Some(sink) = task_id_sink.as_ref() {
+                            let mut g = sink.lock().await;
+                            if g.is_none()
+                                && !event.task_id.is_empty()
+                                && event.task_id != "unknown_task"
+                            {
+                                *g = Some(event.task_id.clone());
+                            }
+                        }
+                        let mut guard = printer.lock().await;
+                        guard.handle_event(&event).await;
+                    }
+                    if let Some(ref msg) = item.message
+                        && msg.role == distri_types::MessageRole::Assistant
+                        && let Some(text) = msg.as_text()
+                        && !text.is_empty()
+                    {
+                        println!("\n{}", text);
+                    }
+                }
+            }
+        })
+        .await;
+    Ok((health_out, result))
+}
+
+/// Resubscribe to a background task's event stream and print events
+/// exactly like `print_stream_with_health`. Used by the CLI when
+/// reopening a thread that has a running task.
+pub async fn print_resubscribe_with_health(
+    client: &AgentStreamClient,
+    agent_id: &str,
+    task_id: &str,
+    verbose: bool,
+    agent_display_name: Option<String>,
+    show_tools: bool,
+    shared_health: Option<Arc<RwLock<ContextHealth>>>,
+) -> Result<(Arc<RwLock<ContextHealth>>, Result<(), StreamError>), StreamError> {
+    let mut printer = EventPrinter::new().with_verbose(verbose);
+    if let Some(name) = agent_display_name {
+        printer = printer.with_agent_name(name);
+    }
+    if !show_tools {
+        printer.toggle_show_tools();
+    }
+    if let Some(ref health) = shared_health {
+        printer.context_health = health.clone();
+    }
+    let health_out = printer.context_health.clone();
+    let printer = Arc::new(Mutex::new(printer));
+    let result = client
+        .resubscribe_task(agent_id, task_id, {
             let printer = printer.clone();
             move |item: StreamItem| {
                 let printer = printer.clone();

--- a/server/distri-core/src/a2a/handler.rs
+++ b/server/distri-core/src/a2a/handler.rs
@@ -428,6 +428,27 @@ impl A2AHandler {
     ) -> Result<serde_json::Value, AgentError> {
         let params: TaskIdParams = serde_json::from_value(params)?;
 
+        // Idempotent cancel: if the task is already in a terminal
+        // state, return its current record without attempting to
+        // cancel again. This lets clients (CLI Ctrl-C, web stop
+        // button) call cancel without worrying about races.
+        if let Ok(Some(existing)) = self
+            .executor
+            .stores
+            .task_store
+            .get_task(&params.id)
+            .await
+        {
+            if matches!(
+                existing.status,
+                distri_types::TaskStatus::Completed
+                    | distri_types::TaskStatus::Canceled
+                    | distri_types::TaskStatus::Failed
+            ) {
+                return Ok(serde_json::to_value(existing)?);
+            }
+        }
+
         // Signal abort via coordinator (sends CancellationSignal, works across nodes)
         if let Err(e) = self.executor.runtime.coordinator().cancel(&params.id).await {
             tracing::warn!("Coordinator cancel failed for {}: {}", params.id, e);

--- a/server/distri-core/src/a2a/stream.rs
+++ b/server/distri-core/src/a2a/stream.rs
@@ -149,12 +149,65 @@ pub async fn init_thread_get_message(
 
 /// Subscribe to events for an existing task via the broadcaster.
 /// Used by the `tasks/resubscribe` A2A method.
+///
+/// Handles the terminal-state race: if the task already finished
+/// before resubscribe is called (or finishes during the subscribe
+/// handshake), we still emit a synthesized final `TaskStatusUpdate`
+/// so the client reliably learns the task's end state instead of
+/// receiving an empty stream.
 pub async fn handle_resubscribe_sse(
     req_id: Option<serde_json::Value>,
     task_id: String,
     executor: Arc<AgentOrchestrator>,
 ) -> impl futures_util::stream::Stream<Item = Result<SseMessage, std::convert::Infallible>> {
     async_stream::stream! {
+        let yield_response = |value: serde_json::Value| SseMessage {
+            event: None,
+            data: serde_json::to_string(&distri_a2a::JsonRpcResponse {
+                jsonrpc: "2.0".to_string(),
+                result: Some(value),
+                error: None,
+                id: req_id.clone(),
+            })
+            .unwrap_or_default(),
+        };
+
+        // Fetch the task up front. If it's already terminal, skip
+        // broadcaster subscribe entirely and emit a synthesized final.
+        let existing_task = executor
+            .stores
+            .task_store
+            .get_task(&task_id)
+            .await
+            .ok()
+            .flatten();
+
+        let is_terminal = |status: &distri_types::TaskStatus| {
+            matches!(
+                status,
+                distri_types::TaskStatus::Completed
+                    | distri_types::TaskStatus::Canceled
+                    | distri_types::TaskStatus::Failed
+            )
+        };
+
+        if let Some(task) = existing_task.as_ref() {
+            if is_terminal(&task.status) {
+                let update = crate::a2a::mapper::create_task_status_update(
+                    task_id.clone(),
+                    task.thread_id.clone(),
+                    map_task_status_to_a2a_state(&task.status),
+                    true,
+                    None,
+                );
+                let kind = distri_a2a::MessageKind::TaskStatusUpdate(update);
+                yield Ok::<_, std::convert::Infallible>(yield_response(
+                    serde_json::to_value(&kind).unwrap_or_default(),
+                ));
+                return;
+            }
+        }
+
         // Subscribe via broadcaster (always available via runtime)
         let event_stream = match executor.broadcaster().subscribe(&task_id).await {
             Ok(s) => s,
@@ -177,20 +230,54 @@ pub async fn handle_resubscribe_sse(
             }
         };
 
+        let mut saw_final = false;
         futures_util::pin_mut!(event_stream);
         while let Some(event) = futures_util::StreamExt::next(&mut event_stream).await {
+            if matches!(
+                event.event,
+                AgentEventType::RunFinished { .. } | AgentEventType::RunError { .. }
+            ) {
+                saw_final = true;
+            }
             let msg = map_agent_event(&event);
-            let response = distri_a2a::JsonRpcResponse {
-                jsonrpc: "2.0".to_string(),
-                result: Some(serde_json::to_value(&msg).unwrap_or_default()),
-                error: None,
-                id: req_id.clone(),
-            };
-            yield Ok::<_, std::convert::Infallible>(SseMessage {
-                event: None,
-                data: serde_json::to_string(&response).unwrap_or_default(),
-            });
+            yield Ok::<_, std::convert::Infallible>(yield_response(
+                serde_json::to_value(&msg).unwrap_or_default(),
+            ));
         }
+
+        // If the broadcaster ended without emitting a terminal event,
+        // it's almost certainly because the task finished in the gap
+        // between our initial get_task() and subscribe(). Re-fetch and
+        // synthesize a final update so the client doesn't hang.
+        if !saw_final {
+            if let Ok(Some(task)) = executor.stores.task_store.get_task(&task_id).await {
+                if is_terminal(&task.status) {
+                    let update = crate::a2a::mapper::create_task_status_update(
+                        task_id.clone(),
+                        task.thread_id.clone(),
+                        map_task_status_to_a2a_state(&task.status),
+                        true,
+                        None,
+                    );
+                    let kind = distri_a2a::MessageKind::TaskStatusUpdate(update);
+                    yield Ok::<_, std::convert::Infallible>(yield_response(
+                        serde_json::to_value(&kind).unwrap_or_default(),
+                    ));
+                }
+            }
+        }
+    }
+}
+
+/// Map our internal `TaskStatus` to the A2A `TaskState` enum used on the wire.
+fn map_task_status_to_a2a_state(status: &distri_types::TaskStatus) -> distri_a2a::TaskState {
+    match status {
+        distri_types::TaskStatus::Pending => distri_a2a::TaskState::Submitted,
+        distri_types::TaskStatus::Running => distri_a2a::TaskState::Working,
+        distri_types::TaskStatus::InputRequired => distri_a2a::TaskState::InputRequired,
+        distri_types::TaskStatus::Completed => distri_a2a::TaskState::Completed,
+        distri_types::TaskStatus::Failed => distri_a2a::TaskState::Failed,
+        distri_types::TaskStatus::Canceled => distri_a2a::TaskState::Canceled,
     }
 }
 

--- a/server/distri-core/src/agent/orchestrator.rs
+++ b/server/distri-core/src/agent/orchestrator.rs
@@ -1056,11 +1056,39 @@ impl AgentOrchestrator {
     }
 
     pub async fn get_thread(&self, thread_id: &str) -> Result<Option<Thread>, AgentError> {
-        self.stores
+        let maybe_thread = self
+            .stores
             .thread_store
             .get_thread(thread_id)
             .await
-            .map_err(|e| AgentError::Session(e.to_string()))
+            .map_err(|e| AgentError::Session(e.to_string()))?;
+
+        // Enrich with active_task_id if a non-terminal task exists for
+        // this thread. This is what clients key off to decide whether
+        // to call `tasks/resubscribe` when reopening the thread.
+        if let Some(mut thread) = maybe_thread {
+            let tasks = self
+                .stores
+                .task_store
+                .list_tasks(Some(thread_id))
+                .await
+                .map_err(|e| AgentError::Session(e.to_string()))?;
+            thread.active_task_id = tasks
+                .into_iter()
+                .filter(|t| {
+                    matches!(
+                        t.status,
+                        distri_types::TaskStatus::Pending
+                            | distri_types::TaskStatus::Running
+                            | distri_types::TaskStatus::InputRequired
+                    )
+                })
+                .max_by_key(|t| t.updated_at)
+                .map(|t| t.id);
+            Ok(Some(thread))
+        } else {
+            Ok(None)
+        }
     }
 
     pub async fn update_thread(

--- a/server/distri-stores/src/diesel_store/mod.rs
+++ b/server/distri-stores/src/diesel_store/mod.rs
@@ -177,6 +177,7 @@ fn to_thread(model: ThreadModel) -> Thread {
         input_tokens: model.input_tokens.max(0) as u64,
         output_tokens: model.output_tokens.max(0) as u64,
         total_tokens: model.total_tokens.max(0) as u64,
+        active_task_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for fire-and-forget background task execution and task resubscription, allowing users to send tasks that continue running on the server while the client exits, and later reattach to monitor their progress.

## Key Changes

### CLI Features
- **Background task execution** (`--background` flag): Send a task and immediately exit while it runs on the server, printing `thread_id` and `task_id` for later reattachment
- **Task reattachment on resume**: When reopening a thread with `--resume`, automatically detect and reattach to any running background task before accepting new input
- **Ctrl-C cancellation**: Implement graceful task cancellation via `tasks/cancel` API with two-tap semantics (first Ctrl-C cancels, second detaches)

### Client Library (`distri`)
- Add `resubscribe_task()` method to `AgentStreamClient` for reconnecting to existing task streams
- Add `cancel_task()` method to `AgentStreamClient` for canceling running tasks
- Extract common SSE handling into `run_sse()` helper method
- Add `print_stream_with_health_ex()` variant that exposes task_id via callback sink
- Add `print_resubscribe_with_health()` for printing resubscribed task events

### Server-Side (`distri-core`)
- **Terminal state race handling**: `handle_resubscribe_sse()` now detects if a task already finished before resubscribe was called and synthesizes a final `TaskStatusUpdate` event so clients reliably learn the end state
- **Idempotent cancellation**: `tasks/cancel` now returns the current task record without error if already terminal, preventing race conditions
- **Thread enrichment**: `get_thread()` now computes and returns `active_task_id` for any non-terminal task in the thread, enabling clients to decide whether to resubscribe
- Add `map_task_status_to_a2a_state()` helper for status mapping

### Data Model
- Add `active_task_id` field to `Thread` struct (computed at read time, never persisted)

## Implementation Details
- Background send polls the stream for up to 5 seconds waiting for a task_id before exiting
- Resubscription uses the same Ctrl-C cancel semantics as fresh streams for consistency
- Server-side synthesized final events handle the race where a task completes between initial fetch and broadcaster subscribe
- All task cancellation is idempotent to safely handle concurrent cancel requests

https://claude.ai/code/session_01Mrkyw83gbu8T6nTurVfmix