### PR TITLE
fix(types,core): cover Part::ResourceLink in remaining match sites

### DIFF
--- a/distri-types/src/execution.rs
+++ b/distri-types/src/execution.rs
@@ -112,6 +112,10 @@ impl ExecutionResult {
                         artifact.file_id, preview, stats_info
                     )
                 }
+                Part::ResourceLink(link) => match link.text.as_deref() {
+                    Some(text) if !text.is_empty() => text.to_string(),
+                    _ => format!("[Resource: {}]", link.uri),
+                },
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -211,6 +215,7 @@ impl ExecutionResult {
                 }
                 Part::File(file) => Part::File(file.clone()),
                 Part::Artifact(artifact) => Part::Artifact(artifact.clone()),
+                Part::ResourceLink(link) => Part::ResourceLink(link.clone()),
             })
             .collect();
 

--- a/server/distri-core/src/agent/context_size_manager.rs
+++ b/server/distri-core/src/agent/context_size_manager.rs
@@ -320,6 +320,20 @@ impl ContextSizeManager {
                         total_tokens += estimate.estimated_tokens;
                     }
                 }
+                crate::types::Part::ResourceLink(link) => {
+                    let link_text = format!(
+                        "{} {}",
+                        link.uri,
+                        link.text.as_deref().unwrap_or("")
+                    );
+                    let estimate = TokenEstimator::estimate_tokens(
+                        &link_text,
+                        self.config.estimation_method.clone(),
+                    );
+                    if let Ok(estimate) = estimate {
+                        total_tokens += estimate.estimated_tokens;
+                    }
+                }
             }
         }
 

--- a/server/distri-core/src/agent/strategy/planning/formatter.rs
+++ b/server/distri-core/src/agent/strategy/planning/formatter.rs
@@ -614,6 +614,9 @@ impl<'a> MessageFormatter<'a> {
                 Part::Artifact(artifact) => {
                     assistant_parts.push(Part::Artifact(artifact.clone()));
                 }
+                Part::ResourceLink(link) => {
+                    assistant_parts.push(Part::ResourceLink(link.clone()));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- PR #98 added \`Part::ResourceLink\` but missed four exhaustive match expressions outside the crates it touched, causing distri-cloud (which bumps this submodule) to fail to compile with E0004.
- Adds match arms in \`distri-types/src/execution.rs\` (\`to_text\`, \`compact_for_history_with\`), \`distri-core/src/agent/context_size_manager.rs\` (\`estimate_message_tokens\`), and \`distri-core/src/agent/strategy/planning/formatter.rs\` (history → assistant fold).

## Behavior
- \`to_text\`: render the optional \`text\` fallback if present, else \`[Resource: <uri>]\`.
- \`compact_for_history_with\`: clone through — resource links are tiny references, no compaction needed.
- \`estimate_message_tokens\`: estimate tokens from \`uri + text\` fallback (mirrors the \`Artifact\` arm).
- Planning formatter: propagate as an assistant part (same pattern as \`Image\`/\`File\`/\`Artifact\`).

## Test plan
- [x] \`cargo check -p distri-cloud\` from the distri-cloud workspace now succeeds with the submodule pinned at this commit.
- [ ] (Optional) \`cargo check\` from inside this repo against \`server/distri-core\`.