### PR TITLE
Add slash command support to StandardAgent

### DIFF
--- a/distri-types/src/agent.rs
+++ b/distri-types/src/agent.rs
@@ -471,6 +471,13 @@ pub struct StandardDefinition {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon_url: Option<String>,
 
+    /// Channel slash commands this agent exposes. Each command is a preset
+    /// prompt — invoking it on a bot sends `prompt` to the agent. Compiled
+    /// into the gateway's `CommandRouter` alongside a `WorkflowAgent`'s
+    /// entry-point commands.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub commands: Vec<crate::channel_commands::SlashCommand>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_iterations: Option<usize>,
 

--- a/distri-types/src/channel_commands.rs
+++ b/distri-types/src/channel_commands.rs
@@ -42,6 +42,31 @@ pub enum ChannelTrigger {
     Message {},
 }
 
+/// A slash command declared by a `StandardAgent` (`StandardDefinition.commands`).
+///
+/// This is the standard-agent counterpart of a `WorkflowAgent`'s entry-point
+/// `ChannelTrigger::Slash`: both surface as channel slash commands, compiled
+/// into the gateway's single `CommandRouter`. A standard-agent command is a
+/// **preset prompt** — invoking it sends `prompt` to the agent as the user
+/// message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema, JsonSchema)]
+pub struct SlashCommand {
+    /// Slash name, e.g. "/summary". Leading "/" required.
+    pub name: String,
+    /// One-line description for `/help` and the channel command menu.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// Alternate names that resolve to this command.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
+    /// Restrict to these providers; empty = all.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub channels: Vec<ChannelProvider>,
+    /// Preset prompt sent to the agent when this command is invoked. Any text
+    /// the user typed after the command is appended.
+    pub prompt: String,
+}
+
 /// Author-facing button template inside a `StepKind::Reply`. Label/url/
 /// callback_data may contain `{...}` interpolation (resolved by the
 /// Reply step executor against workflow context, and `{item.*}` when

--- a/distri-types/src/configuration/package.rs
+++ b/distri-types/src/configuration/package.rs
@@ -18,6 +18,11 @@ pub struct AgentCloudMetadata {
     /// Workspace slug the agent belongs to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_slug: Option<String>,
+    /// When the agent row was last modified. Used as a cache epoch — e.g. the
+    /// gateway keys its compiled `CommandRouter` on `(agent_id, updated_at)`
+    /// so a workflow/command edit invalidates the router.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, JsonSchema)]


### PR DESCRIPTION
## Summary
Adds support for channel slash commands on `StandardAgent`, allowing standard agents to expose preset-prompt commands similar to `WorkflowAgent`'s entry-point triggers. Commands are compiled into the gateway's `CommandRouter` and can be restricted to specific channels.

## Changes
- **New `SlashCommand` struct** in `distri-types/src/channel_commands.rs`:
  - Represents a preset-prompt command with name, description, aliases, and channel restrictions
  - Mirrors `WorkflowAgent`'s `ChannelTrigger::Slash` functionality
  - User text after the command is appended to the preset `prompt`

- **`StandardDefinition.commands` field** in `distri-types/src/agent.rs`:
  - New optional `commands: Vec<SlashCommand>` field to declare slash commands
  - Compiled into gateway's `CommandRouter` alongside workflow agent commands

- **`AgentCloudMetadata.updated_at` field** in `distri-types/src/configuration/package.rs`:
  - Tracks when an agent row was last modified
  - Used as a cache epoch for the gateway's compiled `CommandRouter`
  - Enables cache invalidation on workflow/command edits via `(agent_id, updated_at)` keying

## Implementation Details
- `SlashCommand` includes optional description and aliases for discoverability
- Channel restrictions allow commands to be scoped to specific providers (empty = all channels)
- The `updated_at` timestamp provides a lightweight cache invalidation mechanism without requiring full router recompilation on every agent change

https://claude.ai/code/session_01JE8ZyNBcTBLLRSYZtibkiV