### PR TITLE
Validate handlebars templates at creation/update time

### DIFF
--- a/distri-types/src/prompt.rs
+++ b/distri-types/src/prompt.rs
@@ -534,6 +534,26 @@ impl PromptRegistry {
     }
 }
 
+/// Validate that a user-authored handlebars template (skill body, agent
+/// `instructions`, or stored prompt-template content) renders cleanly under
+/// the same strict-mode pipeline used at execution.
+///
+/// Catches unbalanced `{{` / `}}`, references to partials that aren't
+/// registered, and strict-mode variable lookups against the default
+/// `TemplateData`. Called from `SkillStore`, `AgentStore`, and
+/// `PromptTemplateStore` create/update paths so authors see template
+/// errors at push time instead of at the next agent run.
+///
+/// Empty input is a no-op: an agent with no instructions or a freshly
+/// stubbed-out skill is valid.
+pub async fn validate_template_content(content: &str) -> Result<(), AgentError> {
+    if content.trim().is_empty() {
+        return Ok(());
+    }
+    let registry = PromptRegistry::with_defaults().await?;
+    registry.validate_template(content).await
+}
+
 impl Default for PromptRegistry {
     fn default() -> Self {
         Self::new()

--- a/server/distri-stores/src/diesel_store/mod.rs
+++ b/server/distri-stores/src/diesel_store/mod.rs
@@ -648,6 +648,13 @@ where
     }
 
     async fn register(&self, config: distri_types::configuration::AgentConfig) -> Result<()> {
+        if let distri_types::configuration::AgentConfig::StandardAgent(def) = &config {
+            distri_types::prompt::validate_template_content(&def.instructions)
+                .await
+                .with_context(|| {
+                    format!("agent '{}' has invalid handlebars instructions", def.name)
+                })?;
+        }
         let mut connection = self.conn().await?;
         let name = config.get_name().to_string();
         let serialized =
@@ -3809,6 +3816,14 @@ where
 
     async fn create(&self, template_data: NewPromptTemplate) -> Result<PromptTemplateRecord> {
         use crate::schema::prompt_templates::dsl::*;
+        distri_types::prompt::validate_template_content(&template_data.template)
+            .await
+            .with_context(|| {
+                format!(
+                    "prompt template '{}' has invalid handlebars syntax",
+                    template_data.name
+                )
+            })?;
         let mut conn = self.conn().await?;
         let now = Utc::now().naive_utc();
         let new_id = Uuid::new_v4().to_string();
@@ -3844,6 +3859,14 @@ where
         update_data: UpdatePromptTemplate,
     ) -> Result<PromptTemplateRecord> {
         use crate::schema::prompt_templates::dsl::*;
+        distri_types::prompt::validate_template_content(&update_data.template)
+            .await
+            .with_context(|| {
+                format!(
+                    "prompt template '{}' has invalid handlebars syntax",
+                    update_data.name
+                )
+            })?;
         let mut conn = self.conn().await?;
         let now = Utc::now().naive_utc();
 
@@ -4167,6 +4190,9 @@ where
 
     async fn create(&self, skill: NewSkill) -> Result<SkillRecord> {
         use crate::schema::skills::dsl::*;
+        distri_types::prompt::validate_template_content(&skill.content)
+            .await
+            .with_context(|| format!("skill '{}' has invalid handlebars template", skill.name))?;
         let mut conn = self.conn().await?;
         let now = Utc::now().naive_utc();
         let new_id = Uuid::new_v4().to_string();
@@ -4200,6 +4226,13 @@ where
 
     async fn update(&self, skill_id_val: &str, update: UpdateSkill) -> Result<SkillRecord> {
         use crate::schema::skills::dsl::*;
+        if let Some(ref c) = update.content {
+            distri_types::prompt::validate_template_content(c)
+                .await
+                .with_context(|| {
+                    format!("skill '{}' has invalid handlebars template", skill_id_val)
+                })?;
+        }
         let mut conn = self.conn().await?;
         let now = Utc::now().naive_utc();
 


### PR DESCRIPTION
## Summary

Add validation of handlebars template syntax when agents, prompt templates, and skills are created or updated. This catches template errors (unbalanced delimiters, invalid partials, strict-mode variable lookups) at push time rather than at execution time, providing faster feedback to authors.

## Changes

- **distri-types/src/prompt.rs**: Add `validate_template_content()` function that renders a template through the same strict-mode pipeline used at execution, with special handling for empty content
- **server/distri-stores/src/diesel_store/mod.rs**:
  - `AgentStore::register()`: Validate `StandardAgent` instructions before persisting
  - `PromptTemplateStore::create()`: Validate template content before insert
  - `PromptTemplateStore::update()`: Validate template content before update
  - `SkillStore::create()`: Validate skill content before insert
  - `SkillStore::update()`: Validate skill content if provided in update

## Implementation Details

- Validation is performed asynchronously using the existing `PromptRegistry::with_defaults()` and a new `validate_template()` method
- Empty or whitespace-only templates are treated as valid (no-op)
- Validation errors include context about which resource failed (agent name, template name, skill name)
- Validation happens before database operations, preventing invalid templates from being stored

https://claude.ai/code/session_0156Dkdob4LQMXorohKz7ZRj