### PR TITLE
fix: drop stale --filter=./distri-home from build/dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "ui"
   ],
   "scripts": {
-    "build": "turbo build --filter=./distrijs/packages/core --filter=./distrijs/packages/react  --filter=./distri-home --filter=./distri-ui",
+    "build": "turbo build --filter=./distrijs/packages/core --filter=./distrijs/packages/react --filter=./distri-ui",
     "build:all": "turbo build",
-    "dev": "turbo dev  --filter=./distrijs/packages/core --filter=./distrijs/packages/react --filter=./distri-home --filter=./distri-ui",
+    "dev": "turbo dev --filter=./distrijs/packages/core --filter=./distrijs/packages/react --filter=./distri-ui",
     "lint": "turbo lint",
     "lint:fix": "turbo lint -- --fix",
     "clean": "turbo clean",


### PR DESCRIPTION
The `distri-home` directory was removed from the repo but the turbo `--filter` for it remained in the root `package.json` `build` and `dev` scripts, breaking `pnpm run build` (and by extension `make build-all` / `publish.sh distri`):

```
x Directory '.../distri/distri-home' specified in filter does not exist
ELIFECYCLE Command failed with exit code 1.
make: *** [Makefile:76: frontend-dist] Error 1
cp: cannot stat 'target/x86_64-unknown-linux-gnu/release/distri': No such file or directory
```

Only `./distri-ui` exists alongside the `distrijs/packages/*` workspaces now, so drop the dangling `./distri-home` filter from both scripts.

Surfaced by an attempted `publish.sh distri` run (auto-patch-bump to v0.3.10); no GitHub state was created — the failure happened before any commit/tag/push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)