### PR TITLE
Tracing: propagation, provenance, tags, span naming + CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "distri"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "distri-a2a"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "schemars",
  "serde",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "distri-auth"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "distri-cli"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "distri-core"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-mcp",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "distri-filesystem"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "distri-formatter"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "distri-parsers"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "distri-server"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "actix-cors",
  "actix-files",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "distri-server-cli"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "distri-stores"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "distri-types"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "distri-workflow"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3468,7 +3468,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llm-gateway"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "async-openai",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,6 +1783,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -1790,6 +1791,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.23",
  "tracing",
+ "tracing-opentelemetry 0.29.0",
  "tracing-subscriber",
  "uuid",
  "wiremock",
@@ -1933,7 +1935,7 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
  "utoipa",
 ]
@@ -6294,6 +6296,24 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.27.1",
  "opentelemetry_sdk 0.27.1",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.28.0",
+ "opentelemetry_sdk 0.28.0",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/README.md
+++ b/README.md
@@ -297,6 +297,45 @@ distri profile list / use / config  # Multi-profile management
 
 ---
 
+## Invocation & Traces
+
+Distri has two invocation APIs, both fully traced (agent → steps → LLM → tools,
+with tokens/cost/latency and provenance) in the **Traces** view / `distri traces list`:
+
+| API | Endpoint | What it does |
+| --- | --- | --- |
+| **`execute`** | `POST /v1/agents/{id}` (A2A `message/send` \| `message/stream`) | Run a full agent |
+| **`llm_execute`** | `POST /v1/llm/execute` | A single LLM call (great for high-volume grading/extraction) |
+
+```ts
+// JS (@distri/core)
+const agent = await Agent.create('scoring_agent', client)
+await agent.invoke({ /* messages */, contextId, tags: { team: 'growth' } })   // execute
+await client.llm(messages, tools, { agent_id: 'scoring_agent', thread_id, title })  // llm_execute
+```
+
+```rust
+// Rust (distri client)
+run_agent(&client, RunOptions { agent: Some("scoring_agent".into()), task, thread_id,
+                                tags: Some(tags), trace_context: None, ..Default::default() }, cb).await?;   // execute
+client.llm_execute(LlmExecuteOptions::new(LLmContext { thread_id, label, messages, ..Default::default() })
+                       .with_agent_id("scoring_agent".into())).await?;          // llm_execute
+```
+
+```bash
+distri run --agent scoring_agent --task "grade: 2+2=4" --tag team=growth   # CLI
+```
+
+**Grouping calls into one trace:** give related calls the **same thread / context id**
+(`contextId` on `execute`, `thread_id` on `llm_execute`) — Distri derives the trace id
+from it, so they collapse into a single trace (e.g. all grading calls of one eval run).
+For cross-process propagation, pass an explicit `trace_context { trace_id, parent_span_id }`
+on `execute` to nest the agent's spans under a caller's existing trace.
+
+See the full guide: **[Traces & Tracing Context](https://distri.dev/docs/traces)**.
+
+---
+
 ## Architecture
 
 ```

--- a/distri-a2a/Cargo.toml
+++ b/distri-a2a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-a2a"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 description = "A2A protocol types for the Distri ecosystem"
 license = "MIT"

--- a/distri-cli/Cargo.toml
+++ b/distri-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-cli"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 description = "CLI for the Distri A2A agent platform"
 license = "MIT"
@@ -29,9 +29,9 @@ serde = { workspace = true }
 urlencoding = "2.1"
 
 glob = "0.3"
-distri = { path = "../distri", version = "0.4.0" }
-distri-a2a = { path = "../distri-a2a", version = "0.4.0" }
-distri-types = { path = "../distri-types", version = "0.4.0" }
+distri = { path = "../distri", version = "0.4.2" }
+distri-a2a = { path = "../distri-a2a", version = "0.4.2" }
+distri-types = { path = "../distri-types", version = "0.4.2" }
 async-trait = { workspace = true }
 uuid = { version = "1.13.1", features = ["v4"] }
 tracing-subscriber = { workspace = true }
@@ -47,7 +47,7 @@ base64 = "0.22"
 
 [dev-dependencies]
 tempfile = "3"
-distri-formatter = { path = "../distri-formatter", version = "0.4.0" }
+distri-formatter = { path = "../distri-formatter", version = "0.4.2" }
 
 [dependencies.openssl]
 version = "0.10"

--- a/distri-cli/src/chat.rs
+++ b/distri-cli/src/chat.rs
@@ -404,7 +404,7 @@ pub async fn handle_slash_command(
             if let Some(trace_id) = arg {
                 crate::traces::print_trace_detail(&client, trace_id, None, false).await;
             } else {
-                crate::traces::print_trace_list(&client, 20).await;
+                crate::traces::print_trace_list(&client, 20, None, None).await;
             }
             Ok(SlashCommandResult::Continue)
         }

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -95,6 +95,14 @@ enum Commands {
         /// W3C traceparent header for distributed tracing (passed by SandboxLauncher).
         #[clap(long)]
         traceparent: Option<String>,
+        /// Search tag to attach to this run's traces and thread, as key=value.
+        /// Repeatable: --tag team=growth --tag env=prod
+        #[clap(long = "tag", value_name = "KEY=VALUE")]
+        tags: Vec<String>,
+        /// Extra HTTP header to send with the request, as key=value.
+        /// Repeatable: --header x-trace-source=cli
+        #[clap(long = "header", value_name = "KEY=VALUE")]
+        headers: Vec<String>,
     },
 
     /// Agent-related commands (defaults to list)
@@ -507,6 +515,12 @@ pub(crate) enum TracesCommands {
     List {
         #[clap(long, default_value = "20")]
         limit: i64,
+        /// Filter by agent id/name.
+        #[clap(long)]
+        agent: Option<String>,
+        /// Filter by tag (key=value). Repeatable: --tag team=growth --tag env=prod
+        #[clap(long = "tag", value_name = "KEY=VALUE")]
+        tags: Vec<String>,
     },
     /// Show trace detail with Gantt chart
     Show {
@@ -677,8 +691,12 @@ async fn main() -> Result<()> {
             thread_id,
             remote,
             traceparent,
+            tags,
+            headers,
         } => {
             let extra_tools = parse_cli_overrides(overrides.as_deref());
+            let tag_map = parse_key_value_pairs(&tags);
+            let header_map = parse_key_value_pairs(&headers);
             // Pre-resolve thread_id: explicit --thread-id > DISTRI_THREAD_ID env
             // > --resume. RunOptions only has a single thread_id field and its
             // own env fallback (DISTRI_THREAD_ID), so we resolve --resume here
@@ -714,9 +732,18 @@ async fn main() -> Result<()> {
                 model: None,
                 env_vars,
                 skip_connections_context: false,
-                tags: None,
+                tags: if tag_map.is_empty() {
+                    None
+                } else {
+                    Some(tag_map)
+                },
                 trace_context: None,
             };
+            // Attach any --header values to the client config so every request
+            // (build_run_params + the streaming call) carries them.
+            if !header_map.is_empty() {
+                config.headers = Some(header_map);
+            }
             let agent_name = resolve_agent_name(&run_opts);
 
             // Verify the agent exists before registering anything.
@@ -935,7 +962,11 @@ async fn main() -> Result<()> {
             threads::handle_threads_command(&client, command).await?;
         }
         Commands::Traces { command } => {
-            let command = command.unwrap_or(TracesCommands::List { limit: 20 });
+            let command = command.unwrap_or(TracesCommands::List {
+                limit: 20,
+                agent: None,
+                tags: vec![],
+            });
             traces::handle_traces_command(&client, command).await?;
         }
         Commands::Optimize { command } => {
@@ -1047,6 +1078,22 @@ async fn run_distri_server(
 
 /// Parse `--overrides` JSON into dynamic tool factories.
 /// Expected format: `{"dynamic_tools": [{"name": "...", "factory_type": "http", "config": {...}}]}`
+/// Parse repeated `key=value` CLI args into a map. Accepts `key=value`
+/// (value may contain `=`). Pairs without `=` or with an empty key are skipped
+/// with a warning.
+fn parse_key_value_pairs(pairs: &[String]) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for raw in pairs {
+        match raw.split_once('=') {
+            Some((k, v)) if !k.trim().is_empty() => {
+                map.insert(k.trim().to_string(), v.to_string());
+            }
+            _ => eprintln!("Warning: ignoring malformed key=value pair: '{raw}'"),
+        }
+    }
+    map
+}
+
 fn parse_cli_overrides(json: Option<&str>) -> Vec<distri_types::dynamic_tool::DynamicToolFactory> {
     let Some(json) = json else {
         return Vec::new();

--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -714,6 +714,8 @@ async fn main() -> Result<()> {
                 model: None,
                 env_vars,
                 skip_connections_context: false,
+                tags: None,
+                trace_context: None,
             };
             let agent_name = resolve_agent_name(&run_opts);
 

--- a/distri-cli/src/traces.rs
+++ b/distri-cli/src/traces.rs
@@ -1138,7 +1138,10 @@ pub async fn handle_traces_command(client: &Distri, command: TracesCommands) -> 
             } else {
                 Some(
                     tags.iter()
-                        .filter_map(|raw| raw.split_once('=').map(|(k, v)| format!("{}:{}", k.trim(), v)))
+                        .filter_map(|raw| {
+                            raw.split_once('=')
+                                .map(|(k, v)| format!("{}:{}", k.trim(), v))
+                        })
                         .collect::<Vec<_>>()
                         .join(","),
                 )

--- a/distri-cli/src/traces.rs
+++ b/distri-cli/src/traces.rs
@@ -521,8 +521,13 @@ fn separator(width: usize) -> String {
 // Trace list display
 // ─────────────────────────────────────────────────────────────────────────────
 
-pub async fn print_trace_list(client: &Distri, limit: i64) {
-    match client.list_traces(Some(limit)).await {
+pub async fn print_trace_list(
+    client: &Distri,
+    limit: i64,
+    agent: Option<&str>,
+    tags: Option<&str>,
+) {
+    match client.list_traces_filtered(Some(limit), agent, tags).await {
         Ok(mut traces) => {
             if traces.is_empty() {
                 println!("No traces found.");
@@ -616,6 +621,29 @@ fn print_trace_summary(trace: &TraceSummary, _width: usize) {
         model_str,
         COLOR_RESET,
     );
+
+    // Line 2b: agent provenance + tags
+    let mut prov_parts: Vec<String> = Vec::new();
+    if let Some(ref agent_name) = trace.agent_name {
+        let ver = trace
+            .agent_version
+            .as_deref()
+            .map(|v| format!(" v{}", v))
+            .unwrap_or_default();
+        prov_parts.push(format!("agent: {}{}", agent_name, ver));
+    }
+    if !trace.tags.is_empty() {
+        let mut kvs: Vec<String> = trace
+            .tags
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        kvs.sort();
+        prov_parts.push(format!("[{}]", kvs.join(" ")));
+    }
+    if !prov_parts.is_empty() {
+        println!("  {}{}{}", COLOR_DIM, prov_parts.join("  "), COLOR_RESET);
+    }
 
     // Line 3: input preview (if any)
     if let Some(ref preview) = trace.input_preview {
@@ -1103,8 +1131,19 @@ fn format_value_pretty(text: &str) -> String {
 
 pub async fn handle_traces_command(client: &Distri, command: TracesCommands) -> Result<()> {
     match command {
-        TracesCommands::List { limit } => {
-            print_trace_list(client, limit).await;
+        TracesCommands::List { limit, agent, tags } => {
+            // Convert repeated key=value tag args into the compact wire form.
+            let tags_filter: Option<String> = if tags.is_empty() {
+                None
+            } else {
+                Some(
+                    tags.iter()
+                        .filter_map(|raw| raw.split_once('=').map(|(k, v)| format!("{}:{}", k.trim(), v)))
+                        .collect::<Vec<_>>()
+                        .join(","),
+                )
+            };
+            print_trace_list(client, limit, agent.as_deref(), tags_filter.as_deref()).await;
         }
         TracesCommands::Show {
             id,

--- a/distri-formatter/Cargo.toml
+++ b/distri-formatter/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "distri-formatter"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2024"
 description = "Shared event formatting logic for Distri (plain text, HTML, etc.)"
 license = "MIT"
 repository = "https://github.com/distrihub/distri"
 
 [dependencies]
-distri-types = { path = "../distri-types", version = "0.4.0" }
+distri-types = { path = "../distri-types", version = "0.4.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/distri-types/Cargo.toml
+++ b/distri-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-types"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2024"
 description = "Shared message, tool, and config types for Distri"
 license = "MIT"
@@ -13,7 +13,7 @@ categories = ["api-bindings", "data-structures"]
 
 [dependencies]
 browsr-types = { workspace = true }
-distri-a2a = { path = "../distri-a2a", version = "0.4.0" }
+distri-a2a = { path = "../distri-a2a", version = "0.4.2" }
 
 async-trait = "0.1"
 serde = { workspace = true }

--- a/distri-types/src/api/spans.rs
+++ b/distri-types/src/api/spans.rs
@@ -49,6 +49,14 @@ pub struct TraceRecord {
     pub step_count: i64,
     pub models: Vec<String>,
     pub input_preview: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_version: Option<String>,
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub tags: std::collections::HashMap<String, String>,
 }
 
 /// Response body for `GET /spans`.
@@ -80,6 +88,10 @@ mod tests {
             step_count: 4,
             models: vec!["claude".into()],
             input_preview: Some("hi".into()),
+            agent_id: Some("agent-1".into()),
+            agent_name: Some("coder".into()),
+            agent_version: Some("0.1.0".into()),
+            tags: std::collections::HashMap::new(),
         }
     }
 

--- a/distri-types/src/client_config.rs
+++ b/distri-types/src/client_config.rs
@@ -45,6 +45,12 @@ pub struct DistriConfig {
     #[serde(skip)]
     #[schemars(skip)]
     pub traceparent: Option<String>,
+
+    /// Extra HTTP headers to attach to every request (e.g. set via the
+    /// `--header k=v` CLI flag). Not serialized — runtime only.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub headers: Option<std::collections::HashMap<String, String>>,
 }
 
 fn default_timeout() -> u64 {
@@ -94,6 +100,7 @@ impl Default for DistriConfig {
             timeout_secs: default_timeout(),
             retry_attempts: default_retries(),
             traceparent: None,
+            headers: None,
         }
     }
 }
@@ -190,6 +197,14 @@ impl DistriConfig {
     /// Set the number of retry attempts.
     pub fn with_retries(mut self, retry_attempts: u32) -> Self {
         self.retry_attempts = retry_attempts;
+        self
+    }
+
+    /// Attach extra HTTP headers sent on every request.
+    pub fn with_headers(mut self, headers: std::collections::HashMap<String, String>) -> Self {
+        if !headers.is_empty() {
+            self.headers = Some(headers);
+        }
         self
     }
 

--- a/distri-types/src/configuration/package.rs
+++ b/distri-types/src/configuration/package.rs
@@ -114,6 +114,18 @@ impl AgentConfig {
         }
     }
 
+    /// Resolved agent version. Standard agents fall back to
+    /// `default_agent_version()`; workflow agents carry a required version.
+    pub fn version(&self) -> Option<String> {
+        match self {
+            AgentConfig::StandardAgent(def) => def
+                .version
+                .clone()
+                .or_else(crate::agent::default_agent_version),
+            AgentConfig::WorkflowAgent(def) => Some(def.version.clone()),
+        }
+    }
+
     /// Get the description of the agent
     pub fn get_description(&self) -> &str {
         match self {

--- a/distri-types/src/core.rs
+++ b/distri-types/src/core.rs
@@ -854,6 +854,20 @@ impl FileType {
     }
 }
 
+/// Inbound distributed-trace context, propagated by callers so an agent run
+/// (and all of its descendant spans) nests under a remote parent trace.
+///
+/// Both fields are W3C trace-context hex strings:
+/// - `trace_id`: 32 lowercase hex chars
+/// - `parent_span_id`: 16 lowercase hex chars
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TraceContext {
+    /// W3C trace-id: 32 lowercase hex chars.
+    pub trace_id: String,
+    /// W3C span-id of the remote parent: 16 lowercase hex chars.
+    pub parent_span_id: String,
+}
+
 /// Additional attributes for thread/task metadata.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AdditionalAttributes {
@@ -914,4 +928,14 @@ pub struct ExecutorContextMetadata {
     /// prompts can detect sandbox-context execution.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_sandbox: bool,
+
+    /// Arbitrary caller-supplied tags. Recorded on the agent span (as a JSON
+    /// object under `distri.tags`) and merged into the thread's attributes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tags: Option<std::collections::HashMap<String, String>>,
+
+    /// Inbound distributed-trace context. When present, the agent's root span
+    /// and all descendants inherit this trace_id / parent_span_id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_context: Option<TraceContext>,
 }

--- a/distri-workflow/Cargo.toml
+++ b/distri-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-workflow"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 description = "Workflow engine for Distri — define, execute, and track multi-step workflows"
 license = "MIT"
@@ -15,7 +15,7 @@ uuid = { version = "1", features = ["v4"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing = { workspace = true }
 jsonschema = "0.28"
-distri-types = { path = "../distri-types", version = "0.4.0" }
+distri-types = { path = "../distri-types", version = "0.4.2" }
 anyhow = { workspace = true }
 
 [dev-dependencies]

--- a/distri-workflow/src/tests.rs
+++ b/distri-workflow/src/tests.rs
@@ -76,9 +76,8 @@ mod tests {
 
     #[test]
     fn step_requirement_connection_builder() {
-        let req = StepRequirement::connection("google", "drive").with_permissions(vec![
-            "drive.readonly",
-        ]);
+        let req =
+            StepRequirement::connection("google", "drive").with_permissions(vec!["drive.readonly"]);
         assert_eq!(req.skill, "google:drive");
         assert_eq!(req.permissions, vec!["drive.readonly"]);
     }

--- a/distri-workflow/src/trigger_registry.rs
+++ b/distri-workflow/src/trigger_registry.rs
@@ -107,7 +107,10 @@ impl WorkflowTriggerRegistry for InMemoryWorkflowTriggerRegistry {
         workspace_id: Option<&str>,
         def: &WorkflowDefinition,
     ) -> anyhow::Result<()> {
-        let mut guard = self.bindings.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut guard = self
+            .bindings
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         guard.insert(
             agent_id.to_string(),
             Self::collect_bindings(agent_id, workspace_id, def),
@@ -116,13 +119,19 @@ impl WorkflowTriggerRegistry for InMemoryWorkflowTriggerRegistry {
     }
 
     async fn unregister(&self, agent_id: &str) -> anyhow::Result<()> {
-        let mut guard = self.bindings.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut guard = self
+            .bindings
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         guard.remove(agent_id);
         Ok(())
     }
 
     async fn find_webhook(&self, path: &str) -> anyhow::Result<Option<TriggerBinding>> {
-        let guard = self.bindings.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let guard = self
+            .bindings
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         for entries in guard.values() {
             for binding in entries {
                 if let WorkflowTrigger::Webhook { path: p, .. } = &binding.trigger {
@@ -136,7 +145,10 @@ impl WorkflowTriggerRegistry for InMemoryWorkflowTriggerRegistry {
     }
 
     async fn find_tool(&self, tool_name: &str) -> anyhow::Result<Option<TriggerBinding>> {
-        let guard = self.bindings.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let guard = self
+            .bindings
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         for entries in guard.values() {
             for binding in entries {
                 if let WorkflowTrigger::Tool { name, .. } = &binding.trigger {
@@ -150,7 +162,10 @@ impl WorkflowTriggerRegistry for InMemoryWorkflowTriggerRegistry {
     }
 
     async fn find_event(&self, topic: &str) -> anyhow::Result<Vec<TriggerBinding>> {
-        let guard = self.bindings.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let guard = self
+            .bindings
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         let mut out = Vec::new();
         for entries in guard.values() {
             for binding in entries {
@@ -165,7 +180,10 @@ impl WorkflowTriggerRegistry for InMemoryWorkflowTriggerRegistry {
     }
 
     async fn list_schedules(&self) -> anyhow::Result<Vec<TriggerBinding>> {
-        let guard = self.bindings.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let guard = self
+            .bindings
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         let mut out = Vec::new();
         for entries in guard.values() {
             for binding in entries {
@@ -185,8 +203,8 @@ mod tests {
     use distri_types::workflow_triggers::WebhookAuth;
 
     fn def_with(triggers: Vec<WorkflowTrigger>) -> WorkflowDefinition {
-        WorkflowDefinition::new(vec![WorkflowStep::checkpoint("s", "S", "ok")])
-            .with_entry_points(vec![EntryPoint {
+        WorkflowDefinition::new(vec![WorkflowStep::checkpoint("s", "S", "ok")]).with_entry_points(
+            vec![EntryPoint {
                 id: "main".into(),
                 label: "Main".into(),
                 description: None,
@@ -194,7 +212,8 @@ mod tests {
                 preset_results: Default::default(),
                 required_inputs: vec![],
                 triggers,
-            }])
+            }],
+        )
     }
 
     #[tokio::test]

--- a/distri-workflow/src/types.rs
+++ b/distri-workflow/src/types.rs
@@ -132,8 +132,7 @@ impl WorkflowDefinition {
         use distri_types::WorkflowTrigger;
         use std::collections::HashSet;
 
-        let step_ids: HashSet<&str> =
-            self.steps.iter().map(|s| s.id.as_str()).collect();
+        let step_ids: HashSet<&str> = self.steps.iter().map(|s| s.id.as_str()).collect();
         let mut slash_names: HashSet<String> = HashSet::new();
         let mut callback_ids: HashSet<String> = HashSet::new();
         let mut message_count = 0usize;
@@ -280,7 +279,6 @@ impl WorkflowDefinition {
         Ok(())
     }
 }
-
 
 // ============================================================================
 // Workflow Run (execution state)
@@ -990,8 +988,7 @@ pub enum StepKind {
         buttons_from: Option<String>,
         /// Template applied per `buttons_from` element.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        button_template:
-            Option<distri_types::channel_commands::ReplyButtonSpec>,
+        button_template: Option<distri_types::channel_commands::ReplyButtonSpec>,
     },
 }
 

--- a/distri-workflow/src/workflow_store.rs
+++ b/distri-workflow/src/workflow_store.rs
@@ -162,11 +162,7 @@ pub trait WorkflowStore: Send + Sync {
     // ── step-level ─────────────────────────────────────────────────
 
     /// Insert or update one step's state under a run.
-    async fn upsert_step(
-        &self,
-        run_task_id: &str,
-        step: WorkflowStepState,
-    ) -> anyhow::Result<()>;
+    async fn upsert_step(&self, run_task_id: &str, step: WorkflowStepState) -> anyhow::Result<()>;
 
     /// Load one step's state.
     async fn get_step(
@@ -199,13 +195,19 @@ impl InMemoryWorkflowStore {
 #[async_trait::async_trait]
 impl WorkflowStore for InMemoryWorkflowStore {
     async fn create_run(&self, state: WorkflowExecutionState) -> anyhow::Result<()> {
-        let mut runs = self.runs.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut runs = self
+            .runs
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         runs.insert(state.run_task_id.clone(), state);
         Ok(())
     }
 
     async fn get_run(&self, run_task_id: &str) -> anyhow::Result<Option<WorkflowExecutionState>> {
-        let runs = self.runs.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let runs = self
+            .runs
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         Ok(runs.get(run_task_id).cloned())
     }
 
@@ -214,7 +216,10 @@ impl WorkflowStore for InMemoryWorkflowStore {
         run_task_id: &str,
         context: serde_json::Value,
     ) -> anyhow::Result<()> {
-        let mut runs = self.runs.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut runs = self
+            .runs
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         let row = runs
             .get_mut(run_task_id)
             .ok_or_else(|| anyhow::anyhow!("workflow run not found: {run_task_id}"))?;
@@ -224,19 +229,24 @@ impl WorkflowStore for InMemoryWorkflowStore {
     }
 
     async fn delete_run(&self, run_task_id: &str) -> anyhow::Result<()> {
-        let mut runs = self.runs.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        let mut steps = self.steps.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut runs = self
+            .runs
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut steps = self
+            .steps
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         runs.remove(run_task_id);
         steps.remove(run_task_id);
         Ok(())
     }
 
-    async fn upsert_step(
-        &self,
-        run_task_id: &str,
-        step: WorkflowStepState,
-    ) -> anyhow::Result<()> {
-        let mut steps = self.steps.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+    async fn upsert_step(&self, run_task_id: &str, step: WorkflowStepState) -> anyhow::Result<()> {
+        let mut steps = self
+            .steps
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         let bucket = steps.entry(run_task_id.to_string()).or_default();
         if let Some(existing) = bucket.iter_mut().find(|s| s.step_id == step.step_id) {
             *existing = step;
@@ -251,14 +261,20 @@ impl WorkflowStore for InMemoryWorkflowStore {
         run_task_id: &str,
         step_id: &str,
     ) -> anyhow::Result<Option<WorkflowStepState>> {
-        let steps = self.steps.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let steps = self
+            .steps
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         Ok(steps
             .get(run_task_id)
             .and_then(|bucket| bucket.iter().find(|s| s.step_id == step_id).cloned()))
     }
 
     async fn list_steps(&self, run_task_id: &str) -> anyhow::Result<Vec<WorkflowStepState>> {
-        let steps = self.steps.lock().map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let steps = self
+            .steps
+            .lock()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
         Ok(steps.get(run_task_id).cloned().unwrap_or_default())
     }
 }
@@ -275,9 +291,15 @@ mod tests {
     #[tokio::test]
     async fn create_get_roundtrip() {
         let store = InMemoryWorkflowStore::new();
-        let state = WorkflowExecutionState::new("run-1", "agent-1", "thread-test", "user-test", sample_def())
-            .with_entry_point(Some("main".into()))
-            .with_input(serde_json::json!({"x": 1}));
+        let state = WorkflowExecutionState::new(
+            "run-1",
+            "agent-1",
+            "thread-test",
+            "user-test",
+            sample_def(),
+        )
+        .with_entry_point(Some("main".into()))
+        .with_input(serde_json::json!({"x": 1}));
         store.create_run(state).await.unwrap();
         let got = store.get_run("run-1").await.unwrap().unwrap();
         assert_eq!(got.agent_id, "agent-1");
@@ -290,8 +312,14 @@ mod tests {
         let store = InMemoryWorkflowStore::new();
         store
             .create_run(
-                WorkflowExecutionState::new("run-1", "agent-1", "thread-test", "user-test", sample_def())
-                    .with_input(serde_json::json!({"x": 1})),
+                WorkflowExecutionState::new(
+                    "run-1",
+                    "agent-1",
+                    "thread-test",
+                    "user-test",
+                    sample_def(),
+                )
+                .with_input(serde_json::json!({"x": 1})),
             )
             .await
             .unwrap();
@@ -358,7 +386,10 @@ mod tests {
             .unwrap();
         let r1 = store.list_steps("run-1").await.unwrap();
         let r2 = store.list_steps("run-2").await.unwrap();
-        assert_eq!(r1.iter().map(|s| s.step_id.as_str()).collect::<Vec<_>>(), vec!["a", "b", "c"]);
+        assert_eq!(
+            r1.iter().map(|s| s.step_id.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
         assert_eq!(r2.len(), 1);
     }
 
@@ -366,7 +397,13 @@ mod tests {
     async fn delete_run_cascades_to_steps() {
         let store = InMemoryWorkflowStore::new();
         store
-            .create_run(WorkflowExecutionState::new("run-1", "agent-1", "thread-test", "user-test", sample_def()))
+            .create_run(WorkflowExecutionState::new(
+                "run-1",
+                "agent-1",
+                "thread-test",
+                "user-test",
+                sample_def(),
+            ))
             .await
             .unwrap();
         store

--- a/distri/Cargo.toml
+++ b/distri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2024"
 description = "Rust client for the Distri A2A agent platform"
 license = "MIT"
@@ -24,10 +24,10 @@ tokio = { workspace = true, features = [
 ] }
 reqwest = { workspace = true, features = ["json", "stream", "gzip"] }
 flate2 = "1.0"
-distri-types = { path = "../distri-types", version = "0.4.0" }
-distri-formatter = { path = "../distri-formatter", version = "0.4.0" }
-distri-a2a = { path = "../distri-a2a", version = "0.4.0" }
-distri-workflow = { path = "../distri-workflow", version = "0.4.0" }
+distri-types = { path = "../distri-types", version = "0.4.2" }
+distri-formatter = { path = "../distri-formatter", version = "0.4.2" }
+distri-a2a = { path = "../distri-a2a", version = "0.4.2" }
+distri-workflow = { path = "../distri-workflow", version = "0.4.2" }
 which = "8.0"
 dashmap = "6.1"
 futures-util = "0.3"

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -2763,10 +2763,33 @@ impl Distri {
     // ========== Traces API ==========
 
     pub async fn list_traces(&self, limit: Option<i64>) -> Result<Vec<TraceSummary>, ClientError> {
-        let mut url = format!("{}/traces", self.base_url);
+        self.list_traces_filtered(limit, None, None).await
+    }
+
+    /// List recent traces, optionally filtered by agent id and/or tags.
+    ///
+    /// `tags` uses the compact wire form `key:value,key2:value2`.
+    pub async fn list_traces_filtered(
+        &self,
+        limit: Option<i64>,
+        agent_id: Option<&str>,
+        tags: Option<&str>,
+    ) -> Result<Vec<TraceSummary>, ClientError> {
+        let mut params: Vec<String> = vec![];
         if let Some(limit) = limit {
-            url = format!("{}?limit={}", url, limit);
+            params.push(format!("limit={}", limit));
         }
+        if let Some(agent) = agent_id.filter(|a| !a.is_empty()) {
+            params.push(format!("agent_id={}", urlencoding::encode(agent)));
+        }
+        if let Some(tags) = tags.filter(|t| !t.is_empty()) {
+            params.push(format!("tags={}", urlencoding::encode(tags)));
+        }
+        let url = if params.is_empty() {
+            format!("{}/traces", self.base_url)
+        } else {
+            format!("{}/traces?{}", self.base_url, params.join("&"))
+        };
         let resp = self.http.get(&url).send().await?;
         if !resp.status().is_success() {
             let text = resp.text().await.unwrap_or_default();

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -854,6 +854,7 @@ impl Distri {
     ) -> Result<LlmExecuteResponse, ClientError> {
         let payload = LlmExecuteRequest {
             title: options.context.label,
+            tags: options.tags,
             messages: options.context.messages,
             tools: options.tools,
             thread_id: options.context.thread_id,
@@ -1490,6 +1491,7 @@ pub struct LlmExecuteOptions {
     pub is_sub_task: bool,
     pub agent_id: Option<String>,
     pub load_history: bool,
+    pub tags: Option<HashMap<String, String>>,
 }
 
 impl LlmExecuteOptions {
@@ -1516,6 +1518,11 @@ impl LlmExecuteOptions {
         self
     }
 
+    pub fn with_tags(mut self, tags: HashMap<String, String>) -> Self {
+        self.tags = Some(tags);
+        self
+    }
+
     pub fn with_agent_id(mut self, agent_id: String) -> Self {
         self.agent_id = Some(agent_id);
         self
@@ -1536,6 +1543,8 @@ impl LlmExecuteOptions {
 struct LlmExecuteRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tags: Option<HashMap<String, String>>,
     messages: Vec<Message>,
     #[serde(default)]
     tools: Vec<ExternalTool>,

--- a/distri/src/client.rs
+++ b/distri/src/client.rs
@@ -853,6 +853,7 @@ impl Distri {
         options: LlmExecuteOptions,
     ) -> Result<LlmExecuteResponse, ClientError> {
         let payload = LlmExecuteRequest {
+            title: options.context.label,
             messages: options.context.messages,
             tools: options.tools,
             thread_id: options.context.thread_id,
@@ -1533,6 +1534,8 @@ impl LlmExecuteOptions {
 
 #[derive(Debug, Serialize)]
 struct LlmExecuteRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
     messages: Vec<Message>,
     #[serde(default)]
     tools: Vec<ExternalTool>,

--- a/distri/src/config.rs
+++ b/distri/src/config.rs
@@ -57,6 +57,19 @@ impl BuildHttpClient for DistriConfig {
             headers.insert("traceparent", val);
         }
 
+        // Arbitrary user-supplied headers (e.g. `distri run --header k=v`).
+        // Applied last so callers can override the defaults above if needed.
+        if let Some(ref extra) = self.headers {
+            for (k, v) in extra {
+                if let (Ok(name), Ok(val)) = (
+                    reqwest::header::HeaderName::from_bytes(k.as_bytes()),
+                    reqwest::header::HeaderValue::from_str(v),
+                ) {
+                    headers.insert(name, val);
+                }
+            }
+        }
+
         if !headers.is_empty() {
             builder = builder.default_headers(headers);
         }

--- a/distri/src/message.rs
+++ b/distri/src/message.rs
@@ -57,6 +57,8 @@ pub fn build_message_params(
         false,
         connections_context,
         None,
+        None,
+        None,
     )
 }
 
@@ -68,6 +70,8 @@ pub fn build_message_params_full(
     remote: bool,
     connections_context: Option<String>,
     env_vars: Option<HashMap<String, String>>,
+    tags: Option<HashMap<String, String>>,
+    trace_context: Option<distri_types::TraceContext>,
 ) -> MessageSendParams {
     let has_overrides = model.is_some() || remote;
     // With --remote, the agent will execute on the server (forked into a
@@ -108,6 +112,8 @@ pub fn build_message_params_full(
             None
         },
         env_vars,
+        tags,
+        trace_context,
         ..Default::default()
     };
 
@@ -171,6 +177,8 @@ mod tests {
             true, // remote
             None,
             None,
+            None,
+            None,
         );
         let metadata = parse_metadata(&params);
         assert_eq!(
@@ -198,6 +206,8 @@ mod tests {
             None,
             None,
             false, // local
+            None,
+            None,
             None,
             None,
         );

--- a/distri/src/run.rs
+++ b/distri/src/run.rs
@@ -61,6 +61,12 @@ pub struct RunOptions {
     /// about workspace connections — shipping them back up the wire is
     /// pointless.
     pub skip_connections_context: bool,
+    /// Arbitrary tags forwarded to the server in `ExecutorContextMetadata.tags`.
+    /// Recorded on the agent span and merged into the thread's attributes.
+    pub tags: Option<HashMap<String, String>>,
+    /// Inbound distributed-trace context forwarded in
+    /// `ExecutorContextMetadata.trace_context` for remote-parent propagation.
+    pub trace_context: Option<distri_types::TraceContext>,
 }
 
 /// Resolve the agent name for a run, defaulting to [`DEFAULT_RUN_AGENT`].
@@ -102,6 +108,8 @@ pub async fn build_run_params(platform_client: &Distri, opts: &RunOptions) -> Me
         opts.remote,
         connections_context,
         opts.env_vars.clone(),
+        opts.tags.clone(),
+        opts.trace_context.clone(),
     )
 }
 

--- a/server/distri-auth/Cargo.toml
+++ b/server/distri-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-auth"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 
 [features]
@@ -27,7 +27,7 @@ dirs = "5.0"
 oauth2 = { version = "5", features = ["reqwest"], default-features = false }
 
 # Internal dependencies
-distri-types = { path = "../../distri-types", version = "0.4.0" }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/server/distri-core/Cargo.toml
+++ b/server/distri-core/Cargo.toml
@@ -70,7 +70,13 @@ futures-channel = "0.3"
 bytes = "1.0"
 
 
-opentelemetry = { version = "0.28.0", optional = true }
+# opentelemetry is non-optional: remote-parent trace propagation in
+# agent/hooks/otel.rs needs SpanContext/TraceId/SpanId unconditionally.
+opentelemetry = { version = "0.28.0" }
+# tracing-opentelemetry 0.29 pairs with opentelemetry 0.28. Provides
+# OpenTelemetrySpanExt::set_parent (no-op when no otel layer is installed).
+tracing-opentelemetry = { version = "0.29" }
+sha2 = "0.10"
 opentelemetry_sdk = { version = "0.28.0", optional = true }
 opentelemetry-otlp = { version = "0.28.0", features = [
   "grpc-tonic",

--- a/server/distri-core/Cargo.toml
+++ b/server/distri-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-core"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 
 [features]
@@ -18,18 +18,18 @@ otel = [
 ] # kept for backward compatibility; OTEL is now initialized in binary crates
 
 [dependencies]
-distri-a2a = { path = "../../distri-a2a", version = "0.4.0" }
-distri-parsers = { path = "../distri-parsers", version = "0.4.0" }
-distri = { path = "../../distri", version = "0.4.0" }
+distri-a2a = { path = "../../distri-a2a", version = "0.4.2" }
+distri-parsers = { path = "../distri-parsers", version = "0.4.2" }
+distri = { path = "../../distri", version = "0.4.2" }
 browsr-client = { workspace = true }
 browsr-types = { workspace = true }
-distri-types = { path = "../../distri-types", version = "0.4.0" }
-distri-stores = { path = "../distri-stores", version = "0.4.0", default-features = false }
-distri-filesystem = { path = "../distri-filesystem", version = "0.4.0" }
-distri-auth = { path = "../distri-auth", version = "0.4.0" }
-distri-workflow = { path = "../../distri-workflow", version = "0.4.0" }
-distri-formatter = { path = "../../distri-formatter", version = "0.4.0" }
-llm-gateway = { path = "../llm-gateway", version = "0.4.0" }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
+distri-stores = { path = "../distri-stores", version = "0.4.2", default-features = false }
+distri-filesystem = { path = "../distri-filesystem", version = "0.4.2" }
+distri-auth = { path = "../distri-auth", version = "0.4.2" }
+distri-workflow = { path = "../../distri-workflow", version = "0.4.2" }
+distri-formatter = { path = "../../distri-formatter", version = "0.4.2" }
+llm-gateway = { path = "../llm-gateway", version = "0.4.2" }
 
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/server/distri-core/src/a2a/service.rs
+++ b/server/distri-core/src/a2a/service.rs
@@ -718,6 +718,20 @@ impl A2AService {
         // This ensures threads, events, and tool lookups all use the agent name.
         let agent_id = self.orchestrator.resolve_agent_name(&agent_id).await;
 
+        // Provenance: resolve the agent version from the agent config (falls
+        // back to default_agent_version()). Recorded on the agent span.
+        let agent_version = self
+            .orchestrator
+            .stores
+            .agent_store
+            .get(&agent_id)
+            .await
+            .and_then(|cfg| cfg.version())
+            .or_else(distri_types::default_agent_version);
+
+        let tags = metadata.tags.clone().unwrap_or_default();
+        let trace_context = metadata.trace_context.clone();
+
         let context = ExecutorContext {
             thread_id,
             task_id: params
@@ -739,6 +753,9 @@ impl A2AService {
             dry_run,
             runtime_mode: metadata.runtime_mode,
             is_sandbox: metadata.is_sandbox,
+            tags,
+            agent_version,
+            trace_context,
             ..Default::default()
         };
 

--- a/server/distri-core/src/agent/context.rs
+++ b/server/distri-core/src/agent/context.rs
@@ -185,6 +185,10 @@ pub struct ExecutorContext {
     /// Inbound distributed-trace context. When present (top-level runs only),
     /// the agent's root span and all descendants inherit this trace_id.
     pub trace_context: Option<distri_types::TraceContext>,
+    /// Explicit display name for the agent (root) span. When Some and non-empty,
+    /// it overrides the default `execute {agent}` span name. Child contexts may
+    /// inherit the parent's value or default to None.
+    pub span_name: Option<String>,
 }
 
 impl std::fmt::Debug for ExecutorContext {
@@ -260,6 +264,7 @@ impl Default for ExecutorContext {
             tags: HashMap::new(),
             agent_version: None,
             trace_context: None,
+            span_name: None,
         }
     }
 }
@@ -1311,6 +1316,7 @@ impl ExecutorContext {
             tags: self.tags.clone(),
             agent_version: self.agent_version.clone(),
             trace_context: self.trace_context.clone(),
+            span_name: self.span_name.clone(),
         };
 
         (inner_context, inner_rx)

--- a/server/distri-core/src/agent/context.rs
+++ b/server/distri-core/src/agent/context.rs
@@ -177,6 +177,14 @@ pub struct ExecutorContext {
     /// proxy). The orchestrator uses this post-run to warn when an agent
     /// declared `connections: [...]` but never used them.
     pub connections_used: Arc<RwLock<HashSet<String>>>,
+    /// Arbitrary caller-supplied tags. Recorded on the agent span and merged
+    /// into the thread's attributes. Empty by default.
+    pub tags: HashMap<String, String>,
+    /// Resolved agent version (provenance). Recorded on the agent span.
+    pub agent_version: Option<String>,
+    /// Inbound distributed-trace context. When present (top-level runs only),
+    /// the agent's root span and all descendants inherit this trace_id.
+    pub trace_context: Option<distri_types::TraceContext>,
 }
 
 impl std::fmt::Debug for ExecutorContext {
@@ -249,6 +257,9 @@ impl Default for ExecutorContext {
             mailbox: None,
             is_sandbox: false,
             connections_used: Arc::new(RwLock::new(HashSet::new())),
+            tags: HashMap::new(),
+            agent_version: None,
+            trace_context: None,
         }
     }
 }
@@ -1297,6 +1308,9 @@ impl ExecutorContext {
             mailbox: self.mailbox.clone(),
             is_sandbox: self.is_sandbox,
             connections_used: self.connections_used.clone(),
+            tags: self.tags.clone(),
+            agent_version: self.agent_version.clone(),
+            trace_context: self.trace_context.clone(),
         };
 
         (inner_context, inner_rx)

--- a/server/distri-core/src/agent/hooks/otel.rs
+++ b/server/distri-core/src/agent/hooks/otel.rs
@@ -32,6 +32,67 @@ use llm_gateway::observability::{
     GenAiToolSpan,
 };
 
+/// Build an `opentelemetry::Context` carrying a REMOTE `SpanContext` that the
+/// agent's root span should nest under, so the whole tree inherits one trace_id.
+///
+/// Two sources, in priority order:
+/// 1. An inbound `trace_context` (parse W3C hex trace-id + parent span-id).
+/// 2. A deterministic context derived from the distri `thread_id` (sha2 hash),
+///    so every execution on the same thread shares one trace_id.
+///
+/// Returns `None` only when the inbound trace_context is present but malformed.
+fn remote_parent_context(context: &ExecutorContext) -> Option<opentelemetry::Context> {
+    use opentelemetry::trace::{
+        SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+    };
+
+    let (trace_id, span_id) = if let Some(tc) = &context.trace_context {
+        let trace_id = TraceId::from_hex(&tc.trace_id).ok()?;
+        let span_id = SpanId::from_hex(&tc.parent_span_id).ok()?;
+        (trace_id, span_id)
+    } else {
+        derive_trace_ids_from_thread(&context.thread_id)
+    };
+
+    let span_ctx = SpanContext::new(
+        trace_id,
+        span_id,
+        TraceFlags::SAMPLED,
+        true, // remote
+        TraceState::default(),
+    );
+    Some(opentelemetry::Context::new().with_remote_span_context(span_ctx))
+}
+
+/// Deterministically derive a (TraceId, SpanId) pair from the thread_id via
+/// SHA-256: first 16 bytes → trace-id, next 8 bytes → span-id. Both are forced
+/// non-zero (OTel treats all-zero ids as invalid).
+fn derive_trace_ids_from_thread(
+    thread_id: &str,
+) -> (opentelemetry::trace::TraceId, opentelemetry::trace::SpanId) {
+    use opentelemetry::trace::{SpanId, TraceId};
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(thread_id.as_bytes());
+
+    let mut trace_bytes = [0u8; 16];
+    trace_bytes.copy_from_slice(&digest[0..16]);
+    if trace_bytes.iter().all(|&b| b == 0) {
+        trace_bytes[15] = 1;
+    }
+
+    let mut span_bytes = [0u8; 8];
+    span_bytes.copy_from_slice(&digest[16..24]);
+    if span_bytes.iter().all(|&b| b == 0) {
+        span_bytes[7] = 1;
+    }
+
+    (
+        TraceId::from_bytes(trace_bytes),
+        SpanId::from_bytes(span_bytes),
+    )
+}
+
 /// Hook that creates OTel GenAI spans for every agent run.
 #[derive(Debug, Default)]
 pub struct OtelHooks {
@@ -108,6 +169,19 @@ impl AgentHooks for OtelHooks {
 
         let mut attrs = GenAiAgentSpan::from_context_fields(&context.agent_id, &ctx_fields, None);
         attrs.input_value = input_value;
+        // Provenance: agent version.
+        attrs.agent_version = context.agent_version.clone();
+        // Tags: serialize the map to a JSON object string (only when non-empty).
+        if !context.tags.is_empty() {
+            if let Ok(s) = serde_json::to_string(&context.tags) {
+                attrs.tags_json = Some(s);
+            }
+        }
+        // Record the inbound remote trace context (when given) for debuggability.
+        if let Some(tc) = &context.trace_context {
+            attrs.parent_trace_id = Some(tc.trace_id.clone());
+            attrs.parent_span_id = Some(tc.parent_span_id.clone());
+        }
 
         let span = if let Some(ref parent_run_id) = context.parent_run_id {
             if let Some(outer_span) = self.agent_spans.get(parent_run_id.as_str()) {
@@ -118,6 +192,20 @@ impl AgentHooks for OtelHooks {
         } else {
             builder::agent_span(&attrs)
         };
+
+        // Remote-parent trace propagation for TOP-LEVEL runs only. Sub-agent
+        // runs (parent_run_id is Some) already nest via in_scope() above, so
+        // they inherit the parent's trace_id naturally — leave them alone.
+        //
+        // For a top-level run we attach a REMOTE OpenTelemetry parent so the
+        // whole span tree inherits a single trace_id: either the inbound
+        // trace_context, or a deterministic one derived from the thread_id.
+        if context.parent_run_id.is_none() {
+            if let Some(cx) = remote_parent_context(&context) {
+                use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+                span.set_parent(cx);
+            }
+        }
 
         // Give StandardAgent a clone for .instrument() wrapping
         context.set_otel_agent_span(span.clone());
@@ -426,6 +514,57 @@ mod tests {
     use std::sync::Arc;
 
     use crate::agent::context::ExecutorContext;
+
+    #[test]
+    fn derive_trace_ids_is_deterministic_and_nonzero() {
+        let (t1, s1) = derive_trace_ids_from_thread("thread-abc");
+        let (t2, s2) = derive_trace_ids_from_thread("thread-abc");
+        assert_eq!(t1, t2, "same thread_id → same trace_id");
+        assert_eq!(s1, s2, "same thread_id → same span_id");
+        assert_ne!(t1, opentelemetry::trace::TraceId::INVALID);
+        assert_ne!(s1, opentelemetry::trace::SpanId::INVALID);
+
+        let (t3, _) = derive_trace_ids_from_thread("thread-xyz");
+        assert_ne!(t1, t3, "different thread_id → different trace_id");
+    }
+
+    #[test]
+    fn remote_parent_context_uses_inbound_trace_context() {
+        let ctx = ExecutorContext {
+            thread_id: "t1".to_string(),
+            trace_context: Some(distri_types::TraceContext {
+                trace_id: "0123456789abcdef0123456789abcdef".to_string(),
+                parent_span_id: "0123456789abcdef".to_string(),
+            }),
+            ..Default::default()
+        };
+        // Inbound context parses; helper returns Some.
+        assert!(remote_parent_context(&ctx).is_some());
+    }
+
+    #[test]
+    fn remote_parent_context_rejects_malformed_trace_context() {
+        let ctx = ExecutorContext {
+            thread_id: "t1".to_string(),
+            trace_context: Some(distri_types::TraceContext {
+                trace_id: "not-hex".to_string(),
+                parent_span_id: "nope".to_string(),
+            }),
+            ..Default::default()
+        };
+        assert!(remote_parent_context(&ctx).is_none());
+    }
+
+    #[test]
+    fn remote_parent_context_defaults_to_thread_derived() {
+        let ctx = ExecutorContext {
+            thread_id: "t-default".to_string(),
+            trace_context: None,
+            ..Default::default()
+        };
+        // No inbound context → deterministic thread-derived parent.
+        assert!(remote_parent_context(&ctx).is_some());
+    }
 
     fn make_event(
         base: &distri_types::AgentEvent,

--- a/server/distri-core/src/agent/hooks/otel.rs
+++ b/server/distri-core/src/agent/hooks/otel.rs
@@ -93,6 +93,16 @@ fn derive_trace_ids_from_thread(
     )
 }
 
+/// Truncate `s` to at most `max` chars, appending `…` when truncated.
+fn truncate_span_name(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{}…", truncated)
+    }
+}
+
 /// Hook that creates OTel GenAI spans for every agent run.
 #[derive(Debug, Default)]
 pub struct OtelHooks {
@@ -169,6 +179,17 @@ impl AgentHooks for OtelHooks {
 
         let mut attrs = GenAiAgentSpan::from_context_fields(&context.agent_id, &ctx_fields, None);
         attrs.input_value = input_value;
+        // Span display name: explicit context.span_name wins; else derive a
+        // snippet from the first non-empty line of the message text (≤80 chars).
+        attrs.span_name_override = context
+            .span_name
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| {
+                let text = message.as_text().unwrap_or_default();
+                let line = text.lines().map(str::trim).find(|l| !l.is_empty())?;
+                Some(truncate_span_name(line, 80))
+            });
         // Provenance: agent version.
         attrs.agent_version = context.agent_version.clone();
         // Tags: serialize the map to a JSON object string (only when non-empty).

--- a/server/distri-core/src/agent/orchestrator.rs
+++ b/server/distri-core/src/agent/orchestrator.rs
@@ -1367,10 +1367,7 @@ impl AgentOrchestrator {
         // the run's tags under a "tags" key (object {k:v}) without clobbering
         // any existing attributes.
         let thread_attributes = {
-            let base = context
-                .additional_attributes
-                .clone()
-                .and_then(|a| a.thread);
+            let base = context.additional_attributes.clone().and_then(|a| a.thread);
             if context.tags.is_empty() {
                 base
             } else {
@@ -1378,10 +1375,7 @@ impl AgentOrchestrator {
                     Some(serde_json::Value::Object(m)) => m,
                     _ => serde_json::Map::new(),
                 };
-                obj.insert(
-                    "tags".to_string(),
-                    serde_json::json!(context.tags.clone()),
-                );
+                obj.insert("tags".to_string(), serde_json::json!(context.tags.clone()));
                 Some(serde_json::Value::Object(obj))
             }
         };

--- a/server/distri-core/src/agent/orchestrator.rs
+++ b/server/distri-core/src/agent/orchestrator.rs
@@ -1363,15 +1363,34 @@ impl AgentOrchestrator {
         // Use context stores if provided, otherwise use orchestrator stores
         let stores = context.stores.as_ref().unwrap_or(&self.stores);
 
+        // Base thread attributes from additional_attributes, then merge in
+        // the run's tags under a "tags" key (object {k:v}) without clobbering
+        // any existing attributes.
+        let thread_attributes = {
+            let base = context
+                .additional_attributes
+                .clone()
+                .and_then(|a| a.thread);
+            if context.tags.is_empty() {
+                base
+            } else {
+                let mut obj = match base {
+                    Some(serde_json::Value::Object(m)) => m,
+                    _ => serde_json::Map::new(),
+                };
+                obj.insert(
+                    "tags".to_string(),
+                    serde_json::json!(context.tags.clone()),
+                );
+                Some(serde_json::Value::Object(obj))
+            }
+        };
+
         self.ensure_thread_exists_with_store(
             &agent_name,
             Some(context.thread_id.clone()),
             message.as_text().as_deref(),
-            context
-                .additional_attributes
-                .clone()
-                .map(|a| a.thread)
-                .flatten(),
+            thread_attributes,
             context.channel_id.clone(),
             &stores.thread_store,
         )

--- a/server/distri-core/src/llm_service.rs
+++ b/server/distri-core/src/llm_service.rs
@@ -35,6 +35,7 @@ impl LlmExecuteService {
         title: Option<String>,
         external_id: Option<String>,
         is_sub_task: bool,
+        tags: Option<HashMap<String, String>>,
     ) -> Result<LLMExecuteResult, AgentError> {
         // Generate or use provided thread_id
         let thread_id = thread_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
@@ -54,6 +55,8 @@ impl LlmExecuteService {
         context.tenant_context = tenant_context.clone();
         // Use the thread title (when provided) as the agent span's display name.
         context.span_name = title.clone();
+        // Searchable tags recorded on the agent span as `distri.tags` by OtelHooks.
+        context.tags = tags.unwrap_or_default();
 
         if let Some(run_id) = run_id {
             context.run_id = run_id;

--- a/server/distri-core/src/llm_service.rs
+++ b/server/distri-core/src/llm_service.rs
@@ -52,6 +52,8 @@ impl LlmExecuteService {
         context.thread_id = thread_id.clone();
         context.task_id = task_id.clone();
         context.tenant_context = tenant_context.clone();
+        // Use the thread title (when provided) as the agent span's display name.
+        context.span_name = title.clone();
 
         if let Some(run_id) = run_id {
             context.run_id = run_id;

--- a/server/distri-core/src/runner/local_process.rs
+++ b/server/distri-core/src/runner/local_process.rs
@@ -149,6 +149,8 @@ impl RemoteTaskRunner for LocalProcessRemoteRunner {
                     // Server-side already has connection info; no need to
                     // ship it back up the wire.
                     skip_connections_context: true,
+                    tags: None,
+                    trace_context: None,
                 };
                 if let Err(e) = run_agent(&platform, &stream, opts, |_item| async {}).await {
                     tracing::error!(

--- a/server/distri-filesystem/Cargo.toml
+++ b/server/distri-filesystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-filesystem"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 description = "Filesystem and artifact tools for Distri agents"
 license = "MIT"
@@ -20,7 +20,7 @@ async-trait = "0.1"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
-distri-types = { path = "../../distri-types", version = "0.4.0" }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
 ignore = "0.4"
 regex = "1.0"
 grep = "0.3"

--- a/server/distri-parsers/Cargo.toml
+++ b/server/distri-parsers/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "distri-parsers"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2024"
 
 [dependencies]
 
 
-distri-types = { path = "../../distri-types", version = "0.4.0" }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
 
 
 serde = { workspace = true }

--- a/server/distri-server-cli/Cargo.toml
+++ b/server/distri-server-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-server-cli"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 description = "Distri OSS server binary"
 
@@ -27,10 +27,10 @@ otel = [
 ui = ["distri-server/ui"]
 
 [dependencies]
-distri-core = { path = "../distri-core", version = "0.4.0", default-features = false }
-distri-types = { path = "../../distri-types", version = "0.4.0" }
-distri-filesystem = { path = "../distri-filesystem", version = "0.4.0" }
-distri-server = { path = "../distri-server", version = "0.4.0", default-features = false }
+distri-core = { path = "../distri-core", version = "0.4.2", default-features = false }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
+distri-filesystem = { path = "../distri-filesystem", version = "0.4.2" }
+distri-server = { path = "../distri-server", version = "0.4.2", default-features = false }
 dotenv = "0.15"
 clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = { workspace = true }

--- a/server/distri-server/Cargo.toml
+++ b/server/distri-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distri-server"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 build = "build.rs"
 
@@ -45,14 +45,14 @@ env_logger = "0.11"
 
 tracing = "0.1"
 tracing-subscriber = "0.3"
-distri-core = { path = "../distri-core", version = "0.4.0", default-features = false }
-distri-filesystem = { path = "../distri-filesystem", version = "0.4.0" }
-distri-types = { path = "../../distri-types", version = "0.4.0", features = [
+distri-core = { path = "../distri-core", version = "0.4.2", default-features = false }
+distri-filesystem = { path = "../distri-filesystem", version = "0.4.2" }
+distri-types = { path = "../../distri-types", version = "0.4.2", features = [
   "actix",
 ] }
-distri-a2a = { path = "../../distri-a2a", version = "0.4.0" }
-distri-auth = { path = "../distri-auth", version = "0.4.0" }
-distri-workflow = { path = "../../distri-workflow", version = "0.4.0" }
+distri-a2a = { path = "../../distri-a2a", version = "0.4.2" }
+distri-auth = { path = "../distri-auth", version = "0.4.2" }
+distri-workflow = { path = "../../distri-workflow", version = "0.4.2" }
 
 # Browser automation
 browsr-client = { workspace = true }

--- a/server/distri-server/src/routes.rs
+++ b/server/distri-server/src/routes.rs
@@ -801,6 +801,9 @@ struct LLmRequest {
     /// Optional title for the thread (auto-generated if not provided)
     #[serde(default)]
     title: Option<String>,
+    /// Optional searchable tags recorded on the agent span as `distri.tags`
+    #[serde(default)]
+    tags: Option<HashMap<String, String>>,
 }
 
 fn default_load_history() -> bool {
@@ -1033,6 +1036,7 @@ async fn llm_execute(
             title,
             payload.external_id.clone(),
             payload.is_sub_task,
+            payload.tags.clone(),
         )
         .await;
 

--- a/server/distri-server/src/routes.rs
+++ b/server/distri-server/src/routes.rs
@@ -52,96 +52,108 @@ pub fn all(cfg: &mut web::ServiceConfig) {
 
 // https://github.com/google-a2a/A2A/blob/main/specification/json/a2a.json
 pub fn distri(cfg: &mut web::ServiceConfig) {
-    cfg.service(
-        web::resource(Route::AgentCard.path()).route(web::get().to(get_agent_card)),
-    )
-    .service(
-        web::resource(Route::Agents.path())
-            .route(web::get().to(list_agents))
-            .route(web::post().to(create_agent)),
-    )
-    .service(web::resource(Route::AgentValidate.path()).route(web::get().to(validate_agent_handler)))
-    .service(
-        web::resource(Route::AgentCompleteTool.path())
-            .route(web::post().to(complete_tool_handler)),
-    )
-    .service(web::resource(Route::AgentDag.path()).route(web::get().to(get_agent_dag)))
-    .service(
-        web::resource(Route::AgentDispatch.path())
-            .route(web::get().to(get_agent_definition))
-            .route(web::post().to(a2a_handler))
-            .route(web::put().to(update_agent))
-            .route(web::delete().to(delete_agent)),
-    )
-    .service(web::resource(Route::EventHooks.path()).route(web::post().to(complete_hook_handler)))
-    .service(web::resource(Route::Tasks.path()).route(web::get().to(list_tasks)))
-    .service(web::resource(Route::Tools.path()).route(web::get().to(list_tools)))
-    // Webhook endpoint for triggering agents
-    // Thread endpoints
-    .service(web::resource(Route::Threads.path()).route(web::get().to(list_threads_handler)))
-    .service(web::resource(Route::ThreadsAgents.path()).route(web::get().to(list_agents_by_usage)))
-    .service(
-        web::resource(Route::ThreadMessages.path()).route(web::get().to(get_thread_messages)),
-    )
-    .service(
-        web::resource(Route::Thread.path())
-            .route(web::get().to(get_thread_handler))
-            .route(web::put().to(update_thread_handler))
-            .route(web::delete().to(delete_thread_handler)),
-    )
-    // Message read status endpoints
-    .service(
-        web::resource(Route::ThreadMessageRead.path())
-            .route(web::post().to(mark_message_read_handler))
-            .route(web::get().to(get_message_read_status_handler)),
-    )
-    .service(
-        web::resource(Route::ThreadReadStatus.path())
-            .route(web::get().to(get_thread_read_status_handler)),
-    )
-    // Message voting endpoints
-    .service(
-        web::resource(Route::ThreadMessageVote.path())
-            .route(web::post().to(vote_message_handler))
-            .route(web::delete().to(remove_vote_handler))
-            .route(web::get().to(get_message_vote_summary_handler)),
-    )
-    .service(
-        web::resource(Route::ThreadMessageVotes.path())
-            .route(web::get().to(get_message_votes_handler)),
-    )
-    .service(web::resource(Route::SchemaAgent.path()).route(web::get().to(get_agent_schema))) // Note: External tools and approvals are now handled via message metadata
-    // Workspace file endpoints
-    .service(web::scope(Route::FilesScope.path()).configure(files::configure_file_routes))
-    .service(web::scope(Route::SessionsScope.path()).configure(session::configure_session_routes))
-    // Artifact endpoints (session storage for thread/task artifacts)
-    .service(web::scope(Route::ArtifactsScope.path()).configure(artifacts::configure_artifact_routes))
-    .service(web::resource(Route::Build.path()).route(web::post().to(build_workspace)))
-    .configure(tools::configure)
-    // Browser session endpoint
-    .service(web::resource(Route::BrowserSession.path()).route(web::post().to(create_browser_session)))
-    // LLM execute
-    .service(web::resource(Route::LlmExecute.path()).route(web::post().to(llm_execute)))
-    // Configuration endpoints
-    .service(web::resource(Route::Device.path()).route(web::get().to(get_device_info)))
-    .service(web::resource(Route::HomeStats.path()).route(web::get().to(get_home_stats)))
-    .configure(prompt_templates::configure_prompt_template_routes)
-    // HTTP request proxy — resolves secrets/connections server-side
-    .service(web::resource(Route::Request.path()).route(web::post().to(proxy_request_handler)))
-    .configure(secrets::configure_secret_routes)
-    .configure(providers::configure_provider_routes)
-    .configure(skills::configure_skill_routes)
-    .configure(models::configure_model_routes)
-    // Connection management endpoints
-    .configure(connections::configure_connection_routes)
-    // Notes CRUD endpoints
-    .configure(notes::configure_note_routes)
-    // Spans / traces endpoints
-    .configure(spans::configure_spans_routes)
-    // Usage stats endpoint
-    .configure(usage::configure_usage_routes)
-    // Authentication endpoints
-    .configure(auth_routes::configure_auth_routes);
+    cfg.service(web::resource(Route::AgentCard.path()).route(web::get().to(get_agent_card)))
+        .service(
+            web::resource(Route::Agents.path())
+                .route(web::get().to(list_agents))
+                .route(web::post().to(create_agent)),
+        )
+        .service(
+            web::resource(Route::AgentValidate.path()).route(web::get().to(validate_agent_handler)),
+        )
+        .service(
+            web::resource(Route::AgentCompleteTool.path())
+                .route(web::post().to(complete_tool_handler)),
+        )
+        .service(web::resource(Route::AgentDag.path()).route(web::get().to(get_agent_dag)))
+        .service(
+            web::resource(Route::AgentDispatch.path())
+                .route(web::get().to(get_agent_definition))
+                .route(web::post().to(a2a_handler))
+                .route(web::put().to(update_agent))
+                .route(web::delete().to(delete_agent)),
+        )
+        .service(
+            web::resource(Route::EventHooks.path()).route(web::post().to(complete_hook_handler)),
+        )
+        .service(web::resource(Route::Tasks.path()).route(web::get().to(list_tasks)))
+        .service(web::resource(Route::Tools.path()).route(web::get().to(list_tools)))
+        // Webhook endpoint for triggering agents
+        // Thread endpoints
+        .service(web::resource(Route::Threads.path()).route(web::get().to(list_threads_handler)))
+        .service(
+            web::resource(Route::ThreadsAgents.path()).route(web::get().to(list_agents_by_usage)),
+        )
+        .service(
+            web::resource(Route::ThreadMessages.path()).route(web::get().to(get_thread_messages)),
+        )
+        .service(
+            web::resource(Route::Thread.path())
+                .route(web::get().to(get_thread_handler))
+                .route(web::put().to(update_thread_handler))
+                .route(web::delete().to(delete_thread_handler)),
+        )
+        // Message read status endpoints
+        .service(
+            web::resource(Route::ThreadMessageRead.path())
+                .route(web::post().to(mark_message_read_handler))
+                .route(web::get().to(get_message_read_status_handler)),
+        )
+        .service(
+            web::resource(Route::ThreadReadStatus.path())
+                .route(web::get().to(get_thread_read_status_handler)),
+        )
+        // Message voting endpoints
+        .service(
+            web::resource(Route::ThreadMessageVote.path())
+                .route(web::post().to(vote_message_handler))
+                .route(web::delete().to(remove_vote_handler))
+                .route(web::get().to(get_message_vote_summary_handler)),
+        )
+        .service(
+            web::resource(Route::ThreadMessageVotes.path())
+                .route(web::get().to(get_message_votes_handler)),
+        )
+        .service(web::resource(Route::SchemaAgent.path()).route(web::get().to(get_agent_schema))) // Note: External tools and approvals are now handled via message metadata
+        // Workspace file endpoints
+        .service(web::scope(Route::FilesScope.path()).configure(files::configure_file_routes))
+        .service(
+            web::scope(Route::SessionsScope.path()).configure(session::configure_session_routes),
+        )
+        // Artifact endpoints (session storage for thread/task artifacts)
+        .service(
+            web::scope(Route::ArtifactsScope.path())
+                .configure(artifacts::configure_artifact_routes),
+        )
+        .service(web::resource(Route::Build.path()).route(web::post().to(build_workspace)))
+        .configure(tools::configure)
+        // Browser session endpoint
+        .service(
+            web::resource(Route::BrowserSession.path())
+                .route(web::post().to(create_browser_session)),
+        )
+        // LLM execute
+        .service(web::resource(Route::LlmExecute.path()).route(web::post().to(llm_execute)))
+        // Configuration endpoints
+        .service(web::resource(Route::Device.path()).route(web::get().to(get_device_info)))
+        .service(web::resource(Route::HomeStats.path()).route(web::get().to(get_home_stats)))
+        .configure(prompt_templates::configure_prompt_template_routes)
+        // HTTP request proxy — resolves secrets/connections server-side
+        .service(web::resource(Route::Request.path()).route(web::post().to(proxy_request_handler)))
+        .configure(secrets::configure_secret_routes)
+        .configure(providers::configure_provider_routes)
+        .configure(skills::configure_skill_routes)
+        .configure(models::configure_model_routes)
+        // Connection management endpoints
+        .configure(connections::configure_connection_routes)
+        // Notes CRUD endpoints
+        .configure(notes::configure_note_routes)
+        // Spans / traces endpoints
+        .configure(spans::configure_spans_routes)
+        // Usage stats endpoint
+        .configure(usage::configure_usage_routes)
+        // Authentication endpoints
+        .configure(auth_routes::configure_auth_routes);
 }
 
 /// Agent with stats response

--- a/server/distri-server/src/routes/spans.rs
+++ b/server/distri-server/src/routes/spans.rs
@@ -32,6 +32,19 @@ pub struct SpansQuery {
 #[derive(Debug, Deserialize)]
 pub struct TracesQuery {
     pub limit: Option<i64>,
+    /// Filter by agent id/name.
+    pub agent_id: Option<String>,
+    /// Filter by tags, compact form `key:value,key2:value2` (ANY match key, exact value).
+    pub tags: Option<String>,
+}
+
+/// Parse the compact `k:v,k2:v2` tag filter into pairs.
+fn parse_tag_filter(raw: &str) -> Vec<(String, String)> {
+    raw.split(',')
+        .filter_map(|pair| pair.split_once(':'))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .filter(|(k, _)| !k.is_empty())
+        .collect()
 }
 
 // ── Route registration ────────────────────────────────────────────────────────
@@ -116,8 +129,38 @@ pub async fn list_traces(
     let limit = query.limit.unwrap_or(50).min(200);
     let workspace_id = uuid::Uuid::nil().to_string();
 
-    match store.list_traces(&workspace_id, limit).await {
-        Ok(traces) => HttpResponse::Ok().json(TracesResponse { traces }),
+    let agent_filter = query.agent_id.as_deref().filter(|a| !a.is_empty());
+    let tag_filters = query
+        .tags
+        .as_deref()
+        .map(parse_tag_filter)
+        .unwrap_or_default();
+
+    // When filtering, fetch the full set then narrow in-process (the in-memory
+    // store is local/small), so `limit` applies to the filtered result.
+    let fetch_limit = if agent_filter.is_some() || !tag_filters.is_empty() {
+        200
+    } else {
+        limit
+    };
+
+    match store.list_traces(&workspace_id, fetch_limit).await {
+        Ok(mut traces) => {
+            if let Some(agent) = agent_filter {
+                traces.retain(|t| {
+                    t.agent_id.as_deref() == Some(agent) || t.agent_name.as_deref() == Some(agent)
+                });
+            }
+            if !tag_filters.is_empty() {
+                traces.retain(|t| {
+                    tag_filters
+                        .iter()
+                        .all(|(k, v)| t.tags.get(k).map(|val| val == v).unwrap_or(false))
+                });
+            }
+            traces.truncate(limit as usize);
+            HttpResponse::Ok().json(TracesResponse { traces })
+        }
         Err(e) => {
             tracing::error!(error = ?e, "Failed to query traces");
             HttpResponse::InternalServerError().json(json!({"error": "Failed to query traces"}))

--- a/server/distri-server/src/routes_catalog/mod.rs
+++ b/server/distri-server/src/routes_catalog/mod.rs
@@ -28,7 +28,11 @@ mod tests {
     #[test]
     fn catalog_is_non_empty_and_well_formed() {
         let routes = distri_server_routes();
-        assert!(routes.len() > 20, "expected >20 routes, got {}", routes.len());
+        assert!(
+            routes.len() > 20,
+            "expected >20 routes, got {}",
+            routes.len()
+        );
         for (path, methods) in routes {
             assert!(path.starts_with('/'), "path must start with /: {}", path);
             assert!(!methods.is_empty(), "no methods for {}", path);

--- a/server/distri-server/src/stores.rs
+++ b/server/distri-server/src/stores.rs
@@ -278,17 +278,53 @@ impl SpanStore for InMemorySpanStore {
         let mut records: Vec<TraceRecord> = trace_map
             .into_iter()
             .filter_map(|(trace_id, spans)| {
-                // Root span = no parent_span_id or empty parent_span_id
-                let root = spans.iter().find(|s| {
-                    s.parent_span_id
-                        .as_deref()
-                        .map(|p| p.is_empty())
-                        .unwrap_or(true)
-                })?;
+                // Set of span_ids present in this trace, used to detect dangling
+                // parents (a top-level execute span may now carry a non-null
+                // parent_span_id pointing at a synthetic remote parent that is
+                // not present in the store).
+                let span_ids: std::collections::HashSet<&str> =
+                    spans.iter().map(|s| s.span_id.as_str()).collect();
+
+                // Root candidates = no/empty parent_span_id OR a parent that is
+                // not present among this trace's spans (dangling/remote parent).
+                let is_root = |s: &SpanRecord| -> bool {
+                    match s.parent_span_id.as_deref() {
+                        None => true,
+                        Some(p) if p.is_empty() => true,
+                        Some(p) => !span_ids.contains(p),
+                    }
+                };
+
+                // Pick the earliest execute root for name/preview/agent fields.
+                // Prefer execute spans; fall back to any root span.
+                let mut roots: Vec<&SpanRecord> =
+                    spans.iter().copied().filter(|s| is_root(s)).collect();
+                roots.sort_by_key(|s| s.start_time_ns);
+                let root: &SpanRecord = roots
+                    .iter()
+                    .find(|s| s.name.starts_with("execute"))
+                    .copied()
+                    .or_else(|| roots.first().copied())?;
 
                 let span_count = spans.len() as i64;
                 let start_time_ns = spans.iter().map(|s| s.start_time_ns).min()?;
                 let end_time_ns = spans.iter().map(|s| s.end_time_ns).max()?;
+
+                // Extract agent + tag provenance from the root span's attributes.
+                let attrs = &root.attributes;
+                let str_attr = |key: &str| -> Option<String> {
+                    attrs.get(key).and_then(|v| v.as_str()).map(String::from)
+                };
+                let agent_id = str_attr("gen_ai.agent.id");
+                let agent_name = str_attr("gen_ai.agent.name");
+                let agent_version = str_attr("distri.agent.version");
+                let tags = attrs
+                    .get("distri.tags")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| {
+                        serde_json::from_str::<std::collections::HashMap<String, String>>(s).ok()
+                    })
+                    .unwrap_or_default();
 
                 Some(TraceRecord {
                     trace_id,
@@ -302,6 +338,10 @@ impl SpanStore for InMemorySpanStore {
                     step_count: 0,
                     models: vec![],
                     input_preview: None,
+                    agent_id,
+                    agent_name,
+                    agent_version,
+                    tags,
                 })
             })
             .collect();

--- a/server/distri-stores/Cargo.toml
+++ b/server/distri-stores/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "distri-stores"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2024"
 
 [dependencies]
 anyhow = "1.0"
 async-trait = { workspace = true }
-distri-types = { path = "../../distri-types", version = "0.4.0" }
-distri-filesystem = { path = "../distri-filesystem", version = "0.4.0" }
-distri-auth = { path = "../distri-auth", version = "0.4.0" }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
+distri-filesystem = { path = "../distri-filesystem", version = "0.4.2" }
+distri-auth = { path = "../distri-auth", version = "0.4.2" }
 tracing = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/server/llm-gateway/Cargo.toml
+++ b/server/llm-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm-gateway"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 description = "LLM gateway — unified provider definitions, TTS synthesis, STT transcription, and LLM client abstractions for OpenAI, Anthropic, Azure, ElevenLabs"
 
@@ -8,7 +8,7 @@ description = "LLM gateway — unified provider definitions, TTS synthesis, STT 
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dependencies]
-distri-types = { path = "../../distri-types", version = "0.4.0" }
+distri-types = { path = "../../distri-types", version = "0.4.2" }
 async-openai = { version = "0.32.2", features = [
   "completion-types",
   "chat-completion",

--- a/server/llm-gateway/src/observability/builder.rs
+++ b/server/llm-gateway/src/observability/builder.rs
@@ -130,11 +130,29 @@ pub fn agent_span(attrs: &GenAiAgentSpan) -> tracing::Span {
         "error.code" = tracing::field::Empty,
         "otel.status_code" = tracing::field::Empty,
         "otel.status_description" = tracing::field::Empty,
+        // Declared empty so OtelHooks::before_execute can record them later
+        // (provenance + tags + remote-parent propagation debug attrs).
+        "distri.agent.version" = tracing::field::Empty,
+        "distri.tags" = tracing::field::Empty,
+        "distri.parent_trace_id" = tracing::field::Empty,
+        "distri.parent_span_id" = tracing::field::Empty,
     );
 
     // Record known-at-creation-time optional fields
     if let Some(v) = &attrs.agent_id {
         span.record("gen_ai.agent.id", v.as_str());
+    }
+    if let Some(v) = &attrs.agent_version {
+        span.record("distri.agent.version", v.as_str());
+    }
+    if let Some(v) = &attrs.tags_json {
+        span.record("distri.tags", v.as_str());
+    }
+    if let Some(v) = &attrs.parent_trace_id {
+        span.record("distri.parent_trace_id", v.as_str());
+    }
+    if let Some(v) = &attrs.parent_span_id {
+        span.record("distri.parent_span_id", v.as_str());
     }
     if let Some(v) = &attrs.conversation_id {
         span.record("gen_ai.conversation.id", v.as_str());

--- a/server/llm-gateway/src/observability/types.rs
+++ b/server/llm-gateway/src/observability/types.rs
@@ -111,11 +111,16 @@ pub struct GenAiAgentSpan {
     /// Inbound remote parent span-id (W3C hex) — recorded as
     /// `distri.parent_span_id`.
     pub parent_span_id: Option<String>,
+    /// Explicit span display name; when None, falls back to `execute {agent}`.
+    pub span_name_override: Option<String>,
 }
 
 impl GenAiAgentSpan {
     pub fn span_name(&self) -> String {
-        format!("execute {}", self.agent_name)
+        self.span_name_override
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| format!("execute {}", self.agent_name))
     }
 }
 

--- a/server/llm-gateway/src/observability/types.rs
+++ b/server/llm-gateway/src/observability/types.rs
@@ -101,6 +101,16 @@ pub struct GenAiAgentSpan {
     pub distri_channel_id: Option<String>,
     /// Optional input message text — recorded as input.value on the span.
     pub input_value: Option<String>,
+    /// Resolved agent version (provenance) — recorded as `distri.agent.version`.
+    pub agent_version: Option<String>,
+    /// Caller-supplied tags serialized to a JSON object string — recorded as
+    /// `distri.tags`.
+    pub tags_json: Option<String>,
+    /// Inbound remote trace-id (W3C hex) — recorded as `distri.parent_trace_id`.
+    pub parent_trace_id: Option<String>,
+    /// Inbound remote parent span-id (W3C hex) — recorded as
+    /// `distri.parent_span_id`.
+    pub parent_span_id: Option<String>,
 }
 
 impl GenAiAgentSpan {


### PR DESCRIPTION
## Tracing: remote-parent propagation, provenance, tags, span naming + CLI

Shared types and runtime for the cloud tracing work (paired with distri-cloud #111).

### Propagation & provenance
- `TraceContext` + `tags` on `ExecutorContextMetadata`; remote-parent `set_parent` so an agent's spans inherit an inbound trace, else a deterministic per-thread trace id (groups a thread's runs into one trace).
- Records `distri.agent.version` + `gen_ai.agent.*`; `TraceRecord` exposes `agentId/agentName/agentVersion/tags`.

### Tags on both invoke paths
- Agent `execute`: `RunOptions.tags` → metadata → `distri.tags` span attr.
- `llm_execute`: `LlmExecuteOptions::with_tags` → request → service → `ExecutorContext.tags` → `distri.tags`.

### Span naming
- Agent/root span name = explicit name via `ExecutorContext.span_name` (plumbed from `llm_execute` `title`/label) → first user-message snippet → `execute {agent}`. No DB migration.

### CLI
- `distri run --tag k=v --header k=v` (tags + arbitrary headers via `DistriConfig.headers`).
- `distri traces list --agent <id> --tag k=v` (server-side filtering via `list_traces_filtered`); trace list shows agent name/version + tags.

### Server
- OSS `distri-server` `/traces` honors `agent_id` + `tags` filters (parity with cloud).

All `cargo check` targets pass (per-backend, no `--all-features`); naming/lifecycle unit tests pass.

Note: `distri-server-cli`'s opt-in `otel` feature was already broken on clean HEAD (0.28↔0.29 mismatch) and is left untouched; default builds pass and `set_parent` is a no-op without an otel layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
