### PR TITLE
fix(publish): correct release version source, build distri-server without UI, harden installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ MAKEFLAGS += -j${NPROCS}
 UI_PREFIX ?= ui
 
 ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-DISTRI_VERSION=$(shell awk -F\" '/^version =/ {print $$2; exit}' ${ROOT_DIR}/distri/Cargo.toml)
+# Release version tracks the CLI crate (produces the `distri` binary and is what
+# scripts/publish.env bumps). Must match VERSION_CRATE in scripts/publish.env,
+# else release-tarballs writes to the wrong releases/<version>/ dir.
+DISTRI_VERSION=$(shell awk -F\" '/^version =/ {print $$2; exit}' ${ROOT_DIR}/distri-cli/Cargo.toml)
 RELEASES_DIR=${ROOT_DIR}/releases/${DISTRI_VERSION}
 MAC_ARM_TARGET=aarch64-apple-darwin
 MAC_INTEL_TARGET=x86_64-apple-darwin
@@ -54,29 +57,25 @@ ${TARGETDIR}/distri-server: ${TMPDIR} FORCE
 
 build-all: build-linux build-linux-arm build-mac build-mac-intel
 
+# macOS-only build (used when publishing: Linux targets build on the VM, macOS
+# targets build locally since they can't cross-compile from Linux).
+build-all-mac: build-mac build-mac-intel
+
 build-linux: frontend-dist ${TMPDIR} FORCE
 	cargo zigbuild --profile ${PROFILE} --target ${DEFAULT_CONTAINER_TARGET}.${CONTAINER_GLIBC} -p distri-cli --bin distri
-	@if [ -d "${FRONTEND_DIR}" ]; then \
-		cargo zigbuild --profile ${PROFILE} --target ${DEFAULT_CONTAINER_TARGET}.${CONTAINER_GLIBC} -p distri-server-cli --bin distri-server --features "ui sqlite_vendored"; \
-	fi
+	cargo zigbuild --profile ${PROFILE} --target ${DEFAULT_CONTAINER_TARGET}.${CONTAINER_GLIBC} -p distri-server-cli --bin distri-server --features "sqlite_vendored"
 
 build-linux-arm: frontend-dist ${TMPDIR} FORCE
 	cargo zigbuild --profile ${PROFILE} --target ${LINUX_ARM_TARGET}.${CONTAINER_GLIBC} -p distri-cli --bin distri
-	@if [ -d "${FRONTEND_DIR}" ]; then \
-		cargo zigbuild --profile ${PROFILE} --target ${LINUX_ARM_TARGET}.${CONTAINER_GLIBC} -p distri-server-cli --bin distri-server --features "ui sqlite_vendored"; \
-	fi
+	cargo zigbuild --profile ${PROFILE} --target ${LINUX_ARM_TARGET}.${CONTAINER_GLIBC} -p distri-server-cli --bin distri-server --features "sqlite_vendored"
 
 build-mac: frontend-dist ${TMPDIR} FORCE
 	cargo build --profile ${PROFILE} --target ${MAC_ARM_TARGET} -p distri-cli --bin distri
-	@if [ -d "${FRONTEND_DIR}" ]; then \
-		cargo build --profile ${PROFILE} --target ${MAC_ARM_TARGET} -p distri-server-cli --bin distri-server --features "ui sqlite"; \
-	fi
+	cargo build --profile ${PROFILE} --target ${MAC_ARM_TARGET} -p distri-server-cli --bin distri-server --features "sqlite"
 
 build-mac-intel: frontend-dist ${TMPDIR} FORCE
 	cargo build --profile ${PROFILE} --target ${MAC_INTEL_TARGET} -p distri-cli --bin distri
-	@if [ -d "${FRONTEND_DIR}" ]; then \
-		cargo build --profile ${PROFILE} --target ${MAC_INTEL_TARGET} -p distri-server-cli --bin distri-server --features "ui sqlite"; \
-	fi
+	cargo build --profile ${PROFILE} --target ${MAC_INTEL_TARGET} -p distri-server-cli --bin distri-server --features "sqlite"
 
 build-ui: frontend-dist
 
@@ -142,5 +141,32 @@ release-tarballs: release-dir
 		cp -p ${ROOT_DIR}/target/${LINUX_ARM_TARGET}/release/distri-server ${RELEASE_TMP}/${LINUX_ARM_SLUG}/server/distri-server; \
 	fi
 	tar -czf ${RELEASES_DIR}/distri-${LINUX_ARM_SLUG}.tar.gz -C ${RELEASE_TMP} ${LINUX_ARM_SLUG}
+
+release-tarballs-mac: release-dir
+	@echo "Packaging macOS release tarballs..."
+	@# macOS ARM
+	@if [ -f "${ROOT_DIR}/target/${MAC_ARM_TARGET}/release/distri" ]; then \
+		mkdir -p ${RELEASE_TMP}/${MAC_ARM_SLUG} && \
+		cp -p ${ROOT_DIR}/LICENSE ${RELEASE_TMP}/${MAC_ARM_SLUG}/LICENSE && \
+		cp -p ${ROOT_DIR}/target/${MAC_ARM_TARGET}/release/distri ${RELEASE_TMP}/${MAC_ARM_SLUG}/distri; \
+		if [ -f "${ROOT_DIR}/target/${MAC_ARM_TARGET}/release/distri-server" ]; then \
+			mkdir -p ${RELEASE_TMP}/${MAC_ARM_SLUG}/server && \
+			cp -p ${ROOT_DIR}/server/LICENSE ${RELEASE_TMP}/${MAC_ARM_SLUG}/server/LICENSE && \
+			cp -p ${ROOT_DIR}/target/${MAC_ARM_TARGET}/release/distri-server ${RELEASE_TMP}/${MAC_ARM_SLUG}/server/distri-server; \
+		fi && \
+		tar -czf ${RELEASES_DIR}/distri-${MAC_ARM_SLUG}.tar.gz -C ${RELEASE_TMP} ${MAC_ARM_SLUG}; \
+	fi
+	@# macOS Intel
+	@if [ -f "${ROOT_DIR}/target/${MAC_INTEL_TARGET}/release/distri" ]; then \
+		mkdir -p ${RELEASE_TMP}/${MAC_INTEL_SLUG} && \
+		cp -p ${ROOT_DIR}/LICENSE ${RELEASE_TMP}/${MAC_INTEL_SLUG}/LICENSE && \
+		cp -p ${ROOT_DIR}/target/${MAC_INTEL_TARGET}/release/distri ${RELEASE_TMP}/${MAC_INTEL_SLUG}/distri; \
+		if [ -f "${ROOT_DIR}/target/${MAC_INTEL_TARGET}/release/distri-server" ]; then \
+			mkdir -p ${RELEASE_TMP}/${MAC_INTEL_SLUG}/server && \
+			cp -p ${ROOT_DIR}/server/LICENSE ${RELEASE_TMP}/${MAC_INTEL_SLUG}/server/LICENSE && \
+			cp -p ${ROOT_DIR}/target/${MAC_INTEL_TARGET}/release/distri-server ${RELEASE_TMP}/${MAC_INTEL_SLUG}/server/distri-server; \
+		fi && \
+		tar -czf ${RELEASES_DIR}/distri-${MAC_INTEL_SLUG}.tar.gz -C ${RELEASE_TMP} ${MAC_INTEL_SLUG}; \
+	fi
 
 FORCE: ;

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,27 @@ require_cmd() {
   fi
 }
 
+# Download a URL to a file, resilient to transient network failures.
+# GitHub's release CDN can reset the connection mid-transfer (curl error 56),
+# which a single bare `curl` turns into a failed install. Retry with backoff
+# and resume the partial file (`-C -`) — the CDN supports range requests.
+download() {
+  _url="$1"; _out="$2"
+  _max=5; _n=1
+  while :; do
+    if curl -fL --connect-timeout 30 --retry 3 --retry-delay 2 \
+        --retry-connrefused -C - -o "$_out" "$_url"; then
+      return 0
+    fi
+    if [ "$_n" -ge "$_max" ]; then
+      return 1
+    fi
+    log "download interrupted (attempt ${_n}/${_max}), retrying in $((_n * 3))s..."
+    sleep "$((_n * 3))"
+    _n=$((_n + 1))
+  done
+}
+
 require_cmd curl
 require_cmd tar
 require_cmd uname
@@ -92,11 +113,13 @@ TARBALL="$TMPDIR/$ASSET"
 log "Installing Distri (${TAG_LABEL}) for ${PLATFORM}/${ARCH} into ${INSTALL_DIR}"
 log "Downloading ${DOWNLOAD_URL}"
 
-if ! curl -fL "$DOWNLOAD_URL" -o "$TARBALL"; then
-  fatal "download failed. If you set DISTRI_VERSION, ensure that release exists for ${PLATFORM}/${ARCH}."
+if ! download "$DOWNLOAD_URL" "$TARBALL"; then
+  fatal "download failed after multiple attempts. If you set DISTRI_VERSION, ensure that release exists for ${PLATFORM}/${ARCH}."
 fi
 
-tar -xzf "$TARBALL" -C "$TMPDIR"
+if ! tar -xzf "$TARBALL" -C "$TMPDIR"; then
+  fatal "failed to extract archive (download may be incomplete); please re-run the installer."
+fi
 EXTRACT_ROOT="$TMPDIR/$SLUG"
 BIN_PATH="$EXTRACT_ROOT/distri"
 


### PR DESCRIPTION
## Why

The distri CLI publish pipeline had been silently broken — the last successful release was **v0.3.7** (March), while `Cargo.toml` had advanced to 0.4.4 with no 0.4.x release ever landing. Root-causing the failures surfaced three distinct bugs, all fixed here.

## Fixes

### 1. Release version source mismatch (Makefile ↔ publish.env)
`scripts/publish.env` bumps **`distri-cli/Cargo.toml`**, but the Makefile derived `DISTRI_VERSION` (→ `releases/<ver>/`) from **`distri/Cargo.toml`**. So `make release-tarballs` wrote to `releases/0.4.4/` while `publish.sh` looked in `releases/0.4.5/` → `ERROR: no tarballs found` and an assetless draft release. Both now read `distri-cli/Cargo.toml` (the crate that produces the `distri` binary).

### 2. distri-server never built (moved-frontend guard)
Every build target gated the `distri-server` build on `[ -d distri-ui ]`, but the frontend moved to `distrijs/packages/`, so the server was silently skipped. Now `distri-server` builds unconditionally **without the `ui` feature** (`--features "sqlite_vendored"` on Linux, `"sqlite"` on macOS). `distri-server` has `cfg(not(feature = "ui"))` fallbacks and compiles cleanly (verified). Adds `build-all-mac` + `release-tarballs-mac` so macOS packaging (including `distri-server`) is owned by the source repo.

### 3. Installer aborts on transient network resets
`install.sh` used a single bare `curl -fL`, so one mid-transfer connection reset (`curl: (56) Recv failure: Connection reset by peer`) failed the whole install. Now retries with backoff and resumes the partial file (`-C -`; the release CDN supports range requests), with a clear error if an incomplete archive fails to extract.

## Verification
- `distri-server-cli` (`--features sqlite`, no `ui`) → `cargo check` clean.
- `make -n build-all-mac` / `release-tarballs-mac` parse and expand correctly.
- v0.4.5 (CLI-only) was shipped from these fixes (salvaged manually); this PR makes the **next** publish produce CLI **+ distri-server** for all 4 platforms end-to-end.
- Fixed `install.sh` run end-to-end on darwin/arm64 → installed `distri-cli 0.4.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)