### PR TITLE
Make --overrides model reach the server, and stop dropping unknown frontmatter keys

### DIFF
--- a/distri-cli/src/main.rs
+++ b/distri-cli/src/main.rs
@@ -668,7 +668,9 @@ async fn main() -> Result<()> {
             resume,
             overrides,
         } => {
-            let extra_tools = parse_cli_overrides(overrides.as_deref());
+            let extra_tools = parse_cli_overrides(overrides.as_deref())
+                .dynamic_tools
+                .unwrap_or_default();
             let agent_name = agent.unwrap_or_else(|| "distri".to_string());
             run_interactive_chat(
                 &mut app,
@@ -694,7 +696,9 @@ async fn main() -> Result<()> {
             tags,
             headers,
         } => {
-            let extra_tools = parse_cli_overrides(overrides.as_deref());
+            let cli_overrides = parse_cli_overrides(overrides.as_deref());
+            let override_model = cli_overrides.model.clone();
+            let extra_tools = cli_overrides.dynamic_tools.unwrap_or_default();
             let tag_map = parse_key_value_pairs(&tags);
             let header_map = parse_key_value_pairs(&headers);
             // Pre-resolve thread_id: explicit --thread-id > DISTRI_THREAD_ID env
@@ -729,7 +733,7 @@ async fn main() -> Result<()> {
                 task_id,
                 thread_id: resolved_thread_id,
                 remote,
-                model: None,
+                model: override_model,
                 env_vars,
                 skip_connections_context: false,
                 tags: if tag_map.is_empty() {
@@ -1077,8 +1081,15 @@ async fn run_distri_server(
     Ok(())
 }
 
-/// Parse `--overrides` JSON into dynamic tool factories.
-/// Expected format: `{"dynamic_tools": [{"name": "...", "factory_type": "http", "config": {...}}]}`
+/// Parse the `--overrides` JSON into a `DefinitionOverrides`.
+/// Expected format: `{"model": "...", "dynamic_tools": [{"name": "...", ...}]}`
+///
+/// Every field the caller sets has to be carried through to the request.
+/// Returning only `dynamic_tools` here silently dropped `--overrides
+/// '{"model":"…"}'`: the server honours `definition_overrides.model`
+/// (`AgentDefinition::apply_overrides`) and `RunOptions.model` feeds it, but
+/// the value never left the CLI, so the run went to the workspace default and
+/// said nothing.
 /// Parse repeated `key=value` CLI args into a map. Accepts `key=value`
 /// (value may contain `=`). Pairs without `=` or with an empty key are skipped
 /// with a warning.
@@ -1095,15 +1106,15 @@ fn parse_key_value_pairs(pairs: &[String]) -> std::collections::HashMap<String, 
     map
 }
 
-fn parse_cli_overrides(json: Option<&str>) -> Vec<distri_types::dynamic_tool::DynamicToolFactory> {
+fn parse_cli_overrides(json: Option<&str>) -> distri_types::configuration::DefinitionOverrides {
     let Some(json) = json else {
-        return Vec::new();
+        return Default::default();
     };
     match serde_json::from_str::<distri_types::configuration::DefinitionOverrides>(json) {
-        Ok(overrides) => overrides.dynamic_tools.unwrap_or_default(),
+        Ok(overrides) => overrides,
         Err(e) => {
             eprintln!("Warning: failed to parse --overrides: {e}");
-            Vec::new()
+            Default::default()
         }
     }
 }

--- a/distri-types/src/agent.rs
+++ b/distri-types/src/agent.rs
@@ -2152,6 +2152,61 @@ impl ToolsConfig {
     }
 }
 
+/// The top-level keys `StandardDefinition` actually understands, derived from
+/// its own JSON schema so the list cannot drift from the struct.
+fn known_frontmatter_keys() -> &'static std::collections::HashSet<String> {
+    static KNOWN: std::sync::OnceLock<std::collections::HashSet<String>> =
+        std::sync::OnceLock::new();
+    KNOWN.get_or_init(|| {
+        let schema = schemars::schema_for!(StandardDefinition);
+        serde_json::to_value(schema)
+            .ok()
+            .and_then(|v| v.get("properties").cloned())
+            .and_then(|p| p.as_object().cloned())
+            .map(|props| props.keys().cloned().collect())
+            .unwrap_or_default()
+    })
+}
+
+/// Reject frontmatter keys the definition has no field for.
+///
+/// `StandardDefinition` cannot carry `#[serde(deny_unknown_fields)]`:
+/// `AgentConfigWithTools` *flattens* it next to `resolved_tools`, `markdown`
+/// and the cloud metadata, and serde hands a flattened struct every unmatched
+/// key — denying them there would make every agent read from the server fail.
+/// So the denial lives at the boundary that needs it, the frontmatter a human
+/// writes and `push` sends.
+///
+/// Without this a mistyped key is accepted and discarded in silence. The one
+/// that cost us was a top-level `model = "azure_ai_foundry/gpt-5.4-mini"` —
+/// the model belongs under `[model_settings]`, so the agent was pushed with no
+/// model at all and every run quietly went to the workspace default.
+fn validate_frontmatter_keys(toml_content: &str) -> Result<(), AgentError> {
+    let Ok(table) = toml_content.parse::<toml::Table>() else {
+        return Ok(()); // a genuine syntax error is reported by the real parse
+    };
+    let known = known_frontmatter_keys();
+    let mut unknown: Vec<&str> = table
+        .keys()
+        .map(|k| k.as_str())
+        .filter(|k| !known.contains(*k))
+        .collect();
+    if unknown.is_empty() {
+        return Ok(());
+    }
+    unknown.sort_unstable();
+    let hint = if unknown.contains(&"model") {
+        "\n  hint: the model goes under a [model_settings] table:\n        [model_settings]\n        model = \"provider/model\""
+    } else {
+        ""
+    };
+    Err(AgentError::Validation(format!(
+        "unknown frontmatter key(s): {}. They would be dropped silently, so the push is refused instead.{}",
+        unknown.join(", "),
+        hint
+    )))
+}
+
 pub async fn parse_agent_markdown_content(content: &str) -> Result<StandardDefinition, AgentError> {
     // Split by --- to separate TOML frontmatter from markdown content
     let parts: Vec<&str> = content.split("---").collect();
@@ -2165,6 +2220,7 @@ pub async fn parse_agent_markdown_content(content: &str) -> Result<StandardDefin
 
     // Parse TOML frontmatter (parts[1] is between the first two --- markers)
     let toml_content = parts[1].trim();
+    validate_frontmatter_keys(toml_content)?;
     let mut agent_def: crate::StandardDefinition =
         toml::from_str(toml_content).map_err(|e| AgentError::Validation(e.to_string()))?;
 
@@ -3277,5 +3333,57 @@ tool_format = "json_l"
         };
         assert!(p.base_url_slot_mut().is_none());
         assert!(p.api_key_slot_mut().is_some());
+    }
+
+    /// Regression: a top-level `model` key is not a field on
+    /// `StandardDefinition`, so serde drops it and the agent is pushed with no
+    /// model — every run then silently goes to the workspace default.
+    #[test]
+    fn top_level_model_key_is_refused_with_a_hint() {
+        let err = validate_frontmatter_keys("name = \"probe\"\nmodel = \"alibaba_cloud/qwen3.7-flash\"")
+            .expect_err("a dropped key must not be accepted in silence");
+        let msg = err.to_string();
+        assert!(msg.contains("model"), "names the offending key: {msg}");
+        assert!(msg.contains("model_settings"), "points at the fix: {msg}");
+    }
+
+    #[test]
+    fn model_settings_table_is_accepted() {
+        let toml_in = "name = \"probe\"\n\n[model_settings]\nmodel = \"alibaba_cloud/qwen3.7-flash\"";
+        validate_frontmatter_keys(toml_in).expect("the documented form must pass");
+        // The `provider/model` prefix is resolved later, in
+        // `parse_agent_markdown_content`; raw deserialization keeps it intact.
+        let def: StandardDefinition = toml::from_str(toml_in).expect("and must parse");
+        assert_eq!(
+            def.model_settings.expect("model_settings kept").model,
+            "alibaba_cloud/qwen3.7-flash"
+        );
+    }
+
+    /// A syntax error is the real parser's job to report, not this check's.
+    #[test]
+    fn broken_toml_is_left_to_the_parser() {
+        validate_frontmatter_keys("name = \"unterminated").expect("no opinion on malformed TOML");
+    }
+
+    /// The key list is derived from the schema, so every field the struct
+    /// really has must be accepted in frontmatter.
+    #[test]
+    fn known_keys_cover_the_struct() {
+        let known = known_frontmatter_keys();
+        for key in [
+            "name",
+            "description",
+            "version",
+            "model_settings",
+            "strategy",
+            "tools",
+            "max_iterations",
+            "tool_format",
+            "append_default_instructions",
+            "include_scratchpad",
+        ] {
+            assert!(known.contains(key), "schema-derived keys must include {key}");
+        }
     }
 }


### PR DESCRIPTION
Two silent failures, both of which end with an agent running on a model nobody chose.

## `--overrides '{"model":"…"}'` never left the CLI

`RunOptions.model` exists, is documented as *"Model override. Shows up in `definition_overrides.model`"*, and the server honours it — `apply_overrides` sets `model_settings.model` (`agent.rs`, called from `orchestrator.rs`). But `distri run` hardcoded `model: None`, and `parse_cli_overrides` returned only `overrides.dynamic_tools`, so the value was discarded before the request was built. A nonexistent model id in an override still ran, on the workspace default, without a word.

`parse_cli_overrides` now returns the whole `DefinitionOverrides`; the run path takes `model` from it and the tool path still takes `dynamic_tools`.

Verified against a local server: `--overrides '{"model":"alibaba_cloud/qwen3.6-plus"}'` on an agent pinned to `qwen3.7-flash` now shows `qwen3.6-plus` in `distri traces list`. Before the change the same command showed the pinned model.

## A top-level `model` key in frontmatter was accepted and thrown away

`StandardDefinition` has no `model` field, and no `deny_unknown_fields`, so

```toml
model = "alibaba_cloud/qwen3.7-flash"   # instead of [model_settings]
```

pushed fine, stored `model_settings: null`, and every run fell back to the workspace default. Confirmed by pushing a throwaway agent and reading it back.

`deny_unknown_fields` cannot go on the struct itself: `AgentConfigWithTools` flattens it beside `resolved_tools`, `markdown` and the cloud metadata, and serde hands a flattened struct every unmatched key — denying them there would make every agent read from the server fail. So the check lives at the boundary that needs it, `parse_agent_markdown_content`, over the frontmatter a human writes. The known-key set is derived from the struct's own JSON schema, so it cannot drift from the fields.

A push with an unknown key now fails naming it, and `model` gets a hint:

```
unknown frontmatter key(s): model. They would be dropped silently, so the push is refused instead.
  hint: the model goes under a [model_settings] table:
        [model_settings]
        model = "provider/model"
```

## Tests

Four added in `distri-types`: the refused key with its hint, the accepted `[model_settings]` form, malformed TOML left to the real parser, and a guard that the schema-derived key set still covers the struct's fields. `cargo test -p distri-types --lib` is otherwise unchanged — the 4 failures in that crate (`test_tools_config_is_core_tool`, `test_observation_truncation_fix`, `test_scratchpad_large_observation_issue`, `call_agent_is_always_core`) reproduce on `main` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)